### PR TITLE
DTMT-6 : mongo driver executes script

### DIFF
--- a/src/main/kotlin/datamaintain/Executor.kt
+++ b/src/main/kotlin/datamaintain/Executor.kt
@@ -1,21 +1,11 @@
 package datamaintain
 
-import datamaintain.report.ExecutionLineReport
 import datamaintain.report.ExecutionReport
 import java.time.Instant
 
 class Executor(val config: Config) {
     fun execute(scripts: List<ScriptWithContent>): ExecutionReport {
-        val reportLines = scripts.map { it to config.dbDriver.executeScript(it) }
-                .map { (script, scriptExecutionReport) ->
-                    ExecutionLineReport(
-                            scriptExecutionReport.date,
-                            scriptExecutionReport.message,
-                            scriptExecutionReport.executionStatus,
-                            script
-                    )
-                }
-
+        val reportLines = scripts.map { config.dbDriver.executeScript(it) }
         return ExecutionReport(reportLines, Instant.now())
     }
 }

--- a/src/main/kotlin/datamaintain/ProcessUtil.kt
+++ b/src/main/kotlin/datamaintain/ProcessUtil.kt
@@ -1,0 +1,27 @@
+package datamaintain
+
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+fun List<String>.runProcess(
+        workingDir: File = File("."),
+        timeoutValue: Long = 60,
+        timeoutUnit: TimeUnit = TimeUnit.MINUTES
+): ProcessResult {
+    try {
+        val proc = ProcessBuilder(*this.toTypedArray())
+                .directory(workingDir)
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.PIPE)
+                .start()
+
+        proc.waitFor(timeoutValue, timeoutUnit)
+        return ProcessResult(proc.inputStream.bufferedReader().readText(),
+                proc.exitValue())
+    } catch (e: IOException) {
+        throw IllegalStateException(e.message, e)
+    }
+}
+
+data class ProcessResult(val output: String, val exitCode: Int)

--- a/src/main/kotlin/datamaintain/db/drivers/DatamaintainDriver.kt
+++ b/src/main/kotlin/datamaintain/db/drivers/DatamaintainDriver.kt
@@ -2,12 +2,13 @@ package datamaintain.db.drivers
 
 import datamaintain.Script
 import datamaintain.ScriptWithContent
+import datamaintain.report.ExecutionLineReport
 
 import datamaintain.report.ScriptLineReport
 
 interface DatamaintainDriver {
 
-    fun executeScript(script: ScriptWithContent): ScriptLineReport
+    fun executeScript(script: ScriptWithContent): ExecutionLineReport
 
     fun listExecutedScripts(): Sequence<Script>
 

--- a/src/main/kotlin/datamaintain/db/drivers/FakeDatamaintainDriver.kt
+++ b/src/main/kotlin/datamaintain/db/drivers/FakeDatamaintainDriver.kt
@@ -2,12 +2,13 @@ package datamaintain.db.drivers
 
 import datamaintain.Script
 import datamaintain.ScriptWithContent
+import datamaintain.report.ExecutionLineReport
 
 import datamaintain.report.ScriptLineReport
 
 
 class FakeDatamaintainDriver: DatamaintainDriver {
-    override fun executeScript(script: ScriptWithContent): ScriptLineReport {
+    override fun executeScript(script: ScriptWithContent): ExecutionLineReport {
         throw NotImplementedError("FakeDatamaintainDriver executeScript method should not be used")
     }
 

--- a/src/test/resources/executor_test_files/mongo/mongo_error_insert.js
+++ b/src/test/resources/executor_test_files/mongo/mongo_error_insert.js
@@ -1,0 +1,1 @@
+db.simple.insert({ find: "me", data: 'inserted');

--- a/src/test/resources/executor_test_files/mongo/mongo_simple_insert.js
+++ b/src/test/resources/executor_test_files/mongo/mongo_simple_insert.js
@@ -1,0 +1,1 @@
+db.simple.insert({ find: "me", data: 'inserted'});


### PR DESCRIPTION
$eval mongo command is not available after driver 4.0, so we execute script via an external process

I have handled the case where script is a Filescript, using directly path, otherwise I have used tmp file to execute it.