### PR TITLE
Feat dtmt 27

### DIFF
--- a/modules/cli/src/main/kotlin/datamaintain/cli/App.kt
+++ b/modules/cli/src/main/kotlin/datamaintain/cli/App.kt
@@ -5,17 +5,14 @@ import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.validate
+import datamaintain.core.config.CoreConfigKey
 import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.runDatamaintain
-import datamaintain.core.script.Tag
+import datamaintain.db.driver.mongo.MongoConfigKey
 import datamaintain.db.driver.mongo.MongoDriverConfig
 import java.io.File
-import java.nio.file.Path
-import java.nio.file.Paths
 import java.util.*
 import kotlin.system.exitProcess
-
-val dbValues = listOf("mongo")
 
 class App : CliktCommand() {
 
@@ -23,27 +20,21 @@ class App : CliktCommand() {
             .convert { File(it) }
             .validate { it.exists() }
 
-    private val path: Path? by option(help = "path to directory containing scripts")
-            .convert { Paths.get(it) }
-            .default(Paths.get("./scripts"))
-            .validate { it.toFile().exists() }
-
-    private val dbType: String by option(help = "db type : ${dbValues.joinToString(",")}")
+    private val dbType: String by option(help = "db type : ${DbType.values().joinToString(",") { v -> v.value }}")
             .default("mongo")
-            .validate { dbValues.contains(it) }
+            .validate { DbType.values().map { v -> v.value }.contains(it) }
 
-    private val identifierRegex: Regex? by option(help = "regex to extract identifier part from scripts")
-            .convert { Regex(it) }
+    private val path: String? by option(help = "path to directory containing scripts")
 
-    private val blacklistedTags: Set<Tag>? by option(help = "tags to blacklist")
-            .convert { it.split(",").map { tag -> Tag(tag) }.toSet() }
+    private val identifierRegex: String? by option(help = "regex to extract identifier part from scripts")
+
+    private val blacklistedTags: String? by option(help = "tags to blacklist")
 
     private val mongoDbName: String? by option(help = "mongo db name")
 
     private val mongoUri: String? by option(help = "mongo uri")
 
-    private val mongoTmpPath: Path? by option(help = "mongo tmp file path")
-            .convert { Paths.get(it) }
+    private val mongoTmpPath: String? by option(help = "mongo tmp file path")
 
     override fun run() {
         try {
@@ -51,6 +42,8 @@ class App : CliktCommand() {
             configFilePath?.let {
                 props.load(it.inputStream())
             }
+
+            overloadPropsFromArgs(props)
 
             val config = loadConfig(props)
 
@@ -62,32 +55,32 @@ class App : CliktCommand() {
         }
     }
 
+    private fun overloadPropsFromArgs(props: Properties) {
+        path?.let { props.put(CoreConfigKey.SCAN_PATH.key, it) }
+        identifierRegex?.let { props.put(CoreConfigKey.SCAN_IDENTIFIER_REGEX.key, it) }
+        blacklistedTags?.let { props.put(CoreConfigKey.TAGS_BLACKLISTED.key, it) }
+        mongoDbName?.let { props.put(MongoConfigKey.DB_MONGO_DBNAME.key, it) }
+        mongoUri?.let { props.put(MongoConfigKey.DB_MONGO_URI.key, it) }
+        mongoTmpPath?.let { props.put(MongoConfigKey.DB_MONGO_TMP_PATH.key, it) }
+    }
+
     private fun loadDriverConfig(props: Properties): MongoDriverConfig {
         return when (dbType) {
-            "mongo" -> MongoDriverConfig.buildConfig(props)
+            DbType.MONGO.value -> MongoDriverConfig.buildConfig(props)
             else -> {
                 echo("dbType $dbType is unknown")
                 exitProcess(0)
             }
-        }.let {
-            it.copy(
-                    dbName = this.mongoDbName ?: it.dbName,
-                    mongoUri = this.mongoUri ?: it.mongoUri,
-                    tmpFilePath = this.mongoTmpPath ?: it.tmpFilePath
-            )
         }
     }
 
     private fun loadConfig(props: Properties): DatamaintainConfig {
         val driverConfig = loadDriverConfig(props)
         return DatamaintainConfig.buildConfig(props, driverConfig)
-                .let {
-                    it.copy(
-                            path = this.path ?: it.path,
-                            identifierRegex = this.identifierRegex ?: it.identifierRegex,
-                            blacklistedTags = this.blacklistedTags ?: it.blacklistedTags
-                    )
-                }
+    }
+
+    enum class DbType(val value: String) {
+        MONGO("mongo")
     }
 }
 

--- a/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/MongoDriverConfig.kt
+++ b/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/MongoDriverConfig.kt
@@ -1,7 +1,6 @@
 package datamaintain.db.driver.mongo
 
 import datamaintain.core.config.ConfigKey
-import datamaintain.core.config.getNullableProperty
 import datamaintain.core.config.getProperty
 import datamaintain.core.db.driver.DatamaintainDriverConfig
 import mu.KotlinLogging
@@ -11,29 +10,29 @@ import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
-data class MongoDriverConfig(val dbName: String? = null,
-                             val mongoUri: String? = null,
-                             val tmpFilePath: Path? = null
+data class MongoDriverConfig(val dbName: String,
+                             val mongoUri: String = MongoConfigKey.DB_MONGO_URI.default!!,
+                             val tmpFilePath: Path = Paths.get(MongoConfigKey.DB_MONGO_TMP_PATH.default!!)
 ) : DatamaintainDriverConfig {
     companion object {
         fun buildConfig(props: Properties): MongoDriverConfig {
             return MongoDriverConfig(
-                    props.getNullableProperty(MongoConfigKey.DB_MONGO_DBNAME),
+                    props.getProperty(MongoConfigKey.DB_MONGO_DBNAME),
                     props.getProperty(MongoConfigKey.DB_MONGO_URI),
                     props.getProperty(MongoConfigKey.DB_MONGO_TMP_PATH).let { Paths.get(it) })
         }
     }
 
     override fun toDriver() = MongoDriver(
-            dbName ?: throw IllegalArgumentException("mongo db name is missing"),
-            mongoUri ?: MongoConfigKey.DB_MONGO_URI.default!!,
-            tmpFilePath ?: Paths.get(MongoConfigKey.DB_MONGO_TMP_PATH.default!!))
+            dbName,
+            mongoUri,
+            tmpFilePath)
 
     override fun log() {
         logger.info { "mongo driver configuration: " }
-        dbName?.let { logger.info { "- mongo database name -> $dbName" } }
-        mongoUri?.let { logger.info { "- mongo uri -> $mongoUri" } }
-        tmpFilePath?.let { logger.info { "- mongo tmp file -> $tmpFilePath" } }
+        logger.info { "- mongo database name -> $dbName" }
+        logger.info { "- mongo uri -> $mongoUri" }
+        logger.info { "- mongo tmp file -> $tmpFilePath" }
         logger.info { "" }
     }
 }


### PR DESCRIPTION
parsing arguments in App use only string format. Config class have responsibility of convert values and validate its.

MongoDriverConfig can have same erasure of driver, but it's a data class (driver should not be) Indeed, we can use copy feature to ovveride config, for programmatically usage.

This refactoring is to facilitate DTMT-13 (use jvm properties to overload params)