### PR TITLE
#43 java mongo sample

### DIFF
--- a/modules/cli/build.gradle.kts
+++ b/modules/cli/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 }
 
 application {
-    mainClassName = "datamaintain.AppKt"
+    mainClassName = "datamaintain.cli.AppKt"
 }
 
 graal {

--- a/samples/java-mongo/build.gradle.kts
+++ b/samples/java-mongo/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    id("com.sourcemuse.mongo")
+    maven // Needed for Jitpack
+}
+
+baseProject()
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation(project(":modules:core"))
+    implementation(project(":modules:driver-mongo"))
+    implementation("org.mongodb:mongodb-driver:${Versions.mongoDriver}")
+    implementation("org.jongo:jongo:1.4.1")
+}

--- a/samples/java-mongo/src/main/java/datamaintain/samples/JavaMongoSampleMain.java
+++ b/samples/java-mongo/src/main/java/datamaintain/samples/JavaMongoSampleMain.java
@@ -8,22 +8,22 @@ import datamaintain.db.driver.mongo.MongoDriverConfig;
 import org.jongo.Jongo;
 import org.jongo.MongoCollection;
 
-import java.io.InputStream;
+import java.io.IOException;
+import java.util.Properties;
 
 public class JavaMongoSampleMain {
     private static final String DATABASE_NAME = "datamaintain-sample-java-mongo";
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         // Retrieve datamaintain properties
-        final InputStream propertiesInputStream = JavaMongoSampleMain.class.getResourceAsStream("/config/datamaintain.properties");
+        final Properties properties = new Properties();
+        properties.load(JavaMongoSampleMain.class.getResourceAsStream("/config/datamaintain.properties"));
 
-        String mongoUri = "mongodb://localhost:27017/" + DATABASE_NAME;
+        // Instantiate mongo driver config
+        final DatamaintainDriverConfig datamaintainDriverConfig = MongoDriverConfig.buildConfig(properties);
 
-        // Instanciation du driver Datamaintain.
-        final DatamaintainDriverConfig datamaintainDriverConfig = new MongoDriverConfig(mongoUri);
-
-        // Création de la configuration. À la place de l'inputStream il est possible de passer directement un objet Properties.
-        final DatamaintainConfig config = DatamaintainConfig.buildConfig(propertiesInputStream, datamaintainDriverConfig);
+        // Instantiate datamaintain config
+        final DatamaintainConfig config = DatamaintainConfig.buildConfig(datamaintainDriverConfig, properties);
 
         // Launch database update
         new Datamaintain(config).updateDatabase();
@@ -36,7 +36,6 @@ public class JavaMongoSampleMain {
         return getStartersCollection().findOne().as(Starter.class);
     }
 
-    @Deprecated
     public static MongoCollection getStartersCollection() {
         return new Jongo(new MongoClient().getDB(DATABASE_NAME)).getCollection("starters");
     }

--- a/samples/java-mongo/src/main/java/datamaintain/samples/JavaMongoSampleMain.java
+++ b/samples/java-mongo/src/main/java/datamaintain/samples/JavaMongoSampleMain.java
@@ -13,35 +13,31 @@ import java.io.InputStream;
 public class JavaMongoSampleMain {
     private static final String DATABASE_NAME = "datamaintain-sample-java-mongo";
 
-    public static void main (String[] args) throws Exception {
-        try {
-            // Retrieve datamaintain properties
-            final InputStream propertiesInputStream = JavaMongoSampleMain.class.getResourceAsStream("/config/datamaintain.properties");
+    public static void main(String[] args) {
+        // Retrieve datamaintain properties
+        final InputStream propertiesInputStream = JavaMongoSampleMain.class.getResourceAsStream("/config/datamaintain.properties");
 
-            String mongoUri = "mongodb://localhost:27017/" + DATABASE_NAME;
+        String mongoUri = "mongodb://localhost:27017/" + DATABASE_NAME;
 
-            // Instanciation du driver Datamaintain.
-            final DatamaintainDriverConfig datamaintainDriverConfig = new MongoDriverConfig(mongoUri);
+        // Instanciation du driver Datamaintain.
+        final DatamaintainDriverConfig datamaintainDriverConfig = new MongoDriverConfig(mongoUri);
 
-            // Création de la configuration. À la place de l'inputStream il est possible de passer directement un objet Properties.
-            final DatamaintainConfig config = DatamaintainConfig.buildConfig(propertiesInputStream, datamaintainDriverConfig);
+        // Création de la configuration. À la place de l'inputStream il est possible de passer directement un objet Properties.
+        final DatamaintainConfig config = DatamaintainConfig.buildConfig(propertiesInputStream, datamaintainDriverConfig);
 
-            // Launch database update
-            new Datamaintain(config).updateDatabase();
+        // Launch database update
+        new Datamaintain(config).updateDatabase();
 
-            // Print Charmander
-            System.out.println(loadCharmander());
-        } catch (Exception e) {
-            System.out.println(e.toString());
-        }
+        // Print Charmander
+        System.out.println(loadCharmander());
     }
 
-    private static datamaintain.samples.Starter loadCharmander() throws Exception {
+    private static datamaintain.samples.Starter loadCharmander() {
         return getStartersCollection().findOne().as(Starter.class);
     }
 
     @Deprecated
-    public static MongoCollection getStartersCollection() throws Exception {
+    public static MongoCollection getStartersCollection() {
         return new Jongo(new MongoClient().getDB(DATABASE_NAME)).getCollection("starters");
     }
 

--- a/samples/java-mongo/src/main/java/datamaintain/samples/JavaMongoSampleMain.java
+++ b/samples/java-mongo/src/main/java/datamaintain/samples/JavaMongoSampleMain.java
@@ -1,0 +1,48 @@
+package datamaintain.samples;
+
+import com.mongodb.MongoClient;
+import datamaintain.core.Datamaintain;
+import datamaintain.core.config.DatamaintainConfig;
+import datamaintain.core.db.driver.DatamaintainDriverConfig;
+import datamaintain.db.driver.mongo.MongoDriverConfig;
+import org.jongo.Jongo;
+import org.jongo.MongoCollection;
+
+import java.io.InputStream;
+
+public class JavaMongoSampleMain {
+    private static final String DATABASE_NAME = "datamaintain-sample-java-mongo";
+
+    public static void main (String[] args) throws Exception {
+        try {
+            // Retrieve datamaintain properties
+            final InputStream propertiesInputStream = JavaMongoSampleMain.class.getResourceAsStream("/config/datamaintain.properties");
+
+            String mongoUri = "mongodb://localhost:27017/" + DATABASE_NAME;
+
+            // Instanciation du driver Datamaintain.
+            final DatamaintainDriverConfig datamaintainDriverConfig = new MongoDriverConfig(mongoUri);
+
+            // Création de la configuration. À la place de l'inputStream il est possible de passer directement un objet Properties.
+            final DatamaintainConfig config = DatamaintainConfig.buildConfig(propertiesInputStream, datamaintainDriverConfig);
+
+            // Launch database update
+            new Datamaintain(config).updateDatabase();
+
+            // Print Charmander
+            System.out.println(loadCharmander());
+        } catch (Exception e) {
+            System.out.println(e.toString());
+        }
+    }
+
+    private static datamaintain.samples.Starter loadCharmander() throws Exception {
+        return getStartersCollection().findOne().as(Starter.class);
+    }
+
+    @Deprecated
+    public static MongoCollection getStartersCollection() throws Exception {
+        return new Jongo(new MongoClient().getDB(DATABASE_NAME)).getCollection("starters");
+    }
+
+}

--- a/samples/java-mongo/src/main/java/datamaintain/samples/Starter.java
+++ b/samples/java-mongo/src/main/java/datamaintain/samples/Starter.java
@@ -1,0 +1,100 @@
+package datamaintain.samples;
+
+import java.util.List;
+
+public class Starter {
+    private String name;
+    private List<String> types;
+    private int hp;
+    private int attack;
+    private int defense;
+    private int specialAttack;
+    private int specialDefense;
+    private int speed;
+
+    public String getName() {
+        return name;
+    }
+
+    public Starter setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public List<String> getTypes() {
+        return types;
+    }
+
+    public Starter setTypes(List<String> types) {
+        this.types = types;
+        return this;
+    }
+
+    public int getHp() {
+        return hp;
+    }
+
+    public Starter setHp(int hp) {
+        this.hp = hp;
+        return this;
+    }
+
+    public int getAttack() {
+        return attack;
+    }
+
+    public Starter setAttack(int attack) {
+        this.attack = attack;
+        return this;
+    }
+
+    public int getDefense() {
+        return defense;
+    }
+
+    public Starter setDefense(int defense) {
+        this.defense = defense;
+        return this;
+    }
+
+    public int getSpecialAttack() {
+        return specialAttack;
+    }
+
+    public Starter setSpecialAttack(int specialAttack) {
+        this.specialAttack = specialAttack;
+        return this;
+    }
+
+    public int getSpecialDefense() {
+        return specialDefense;
+    }
+
+    public Starter setSpecialDefense(int specialDefense) {
+        this.specialDefense = specialDefense;
+        return this;
+    }
+
+    public int getSpeed() {
+        return speed;
+    }
+
+    public Starter setSpeed(int speed) {
+        this.speed = speed;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Starter{" +
+                "name='" + name + '\'' +
+                ", types=" + types +
+                ", hp=" + hp +
+                ", attack=" + attack +
+                ", defense=" + defense +
+                ", specialAttack=" + specialAttack +
+                ", specialDefense=" + specialDefense +
+                ", speed=" + speed +
+                '}';
+    }
+}

--- a/samples/java-mongo/src/main/resources/config/datamaintain.properties
+++ b/samples/java-mongo/src/main/resources/config/datamaintain.properties
@@ -1,0 +1,2 @@
+scan.path=samples/java-mongo/src/main/resources/scripts
+scan.identifier.regex=(.*?)_.*

--- a/samples/java-mongo/src/main/resources/config/datamaintain.properties
+++ b/samples/java-mongo/src/main/resources/config/datamaintain.properties
@@ -1,2 +1,3 @@
 scan.path=samples/java-mongo/src/main/resources/scripts
 scan.identifier.regex=(.*?)_.*
+db.mongo.uri=mongodb://localhost:27017/datamaintain-sample-java-mongo

--- a/samples/java-mongo/src/main/resources/scripts/1_add-gen1-charmander.js
+++ b/samples/java-mongo/src/main/resources/scripts/1_add-gen1-charmander.js
@@ -1,0 +1,9 @@
+db.starters.save({
+    "name": "Charmander",
+    "types": ["Fire"],
+    "hp": 39,
+    "attack": 52,
+    "defense": 43,
+    "special": 50,
+    "speed": 65
+});

--- a/samples/java-mongo/src/main/resources/scripts/2_split-charmander-special-stat.js
+++ b/samples/java-mongo/src/main/resources/scripts/2_split-charmander-special-stat.js
@@ -1,0 +1,6 @@
+var charmander = db.starters.findOne({"name": "Charmander"});
+db.starters.update(
+    {_id: charmander._id},
+    {$set: {specialAttack: charmander.special, specialDefense: charmander.special}},
+    {$unset: {special: undefined}}
+);

--- a/samples/java-mongo/src/main/resources/scripts/3_update-charmander-special-attack.js
+++ b/samples/java-mongo/src/main/resources/scripts/3_update-charmander-special-attack.js
@@ -1,0 +1,1 @@
+db.starters.update({"name": "Charmander"}, {$set: {specialAttack: 60}});

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,5 +3,6 @@ include(
         "modules:core",
         "modules:cli",
         "modules:driver-mongo",
-        "modules:test"
+        "modules:test",
+        "samples:java-mongo"
 )


### PR DESCRIPTION
Add sample to show the use of datamaintain within a java project. 

The sample project executes Datamaintain with scripts that are to be run in a particular order and then displays the data inserted in database. Configuration for both ```DatamaintainConfig``` and ```DatamaintainDriverConfig ``` is loaded from a properties file.

Closes #43

@mrenou @nroulon 