### PR TITLE
fix: #107 Allow relative path matchers but forbid unresolved environment variables

### DIFF
--- a/modules/core/src/main/kotlin/datamaintain/core/script/TagMatcher.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/script/TagMatcher.kt
@@ -40,19 +40,19 @@ class TagMatcher(val tag: Tag, val globPaths: Iterable<String>) {
         fun parse(name: String, pathMatchers: String): TagMatcher {
             return TagMatcher(Tag(name = name), pathMatchers.split(",")
                     .map { pathMatcher -> pathMatcher.trim('[', ']', ' ') }
-                    .onEach { if (isNotAbsolute(it)) { throw  NotAbsolutePathMatcherPathException(name, it)} }
+                    .onEach { if (containsEnvironmentVariables(it)) { throw  PathMatcherUsesEnvironmentVariables(name, it)} }
                     .toSet())
         }
 
         @JvmStatic
-        private fun isNotAbsolute(pathMatcher: String): Boolean {
-            return pathMatcher.startsWith("~") || pathMatcher.contains("../") || pathMatcher.startsWith("./")
+        private fun containsEnvironmentVariables(pathMatcher: String): Boolean {
+            return pathMatcher.startsWith("~") || pathMatcher.startsWith("\$HOME")
         }
     }
 }
 
-class NotAbsolutePathMatcherPathException(name: String, pathMatcher: String):
-        IllegalArgumentException("The path matcher '${pathMatcher}' given to match scripts for the tag named '${name}' is not absolute " +
-                "(it contains '../' or starts with a ~). " +
-                "Datamaintain only support absolute paths. You may find it using the command pwd" +
-                " in the concerned folder.")
+class PathMatcherUsesEnvironmentVariables(name: String, pathMatcher: String):
+        IllegalArgumentException("The path matcher '${pathMatcher}' given to match scripts for the tag named '${name}' is not valid " +
+                "because it starts with a '~' or '\$HOME'. You can not use such environments variables in the settings.\n" +
+                "You may want to give the absolute path to your folder. If that is what you want, you can find it using " +
+                "the command `pwd` in the concerned folder.\n")

--- a/modules/core/src/test/kotlin/datamaintain/core/script/TagMatcherTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/script/TagMatcherTest.kt
@@ -4,10 +4,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import strikt.api.expectCatching
 import strikt.api.expectThat
-import strikt.assertions.containsExactly
-import strikt.assertions.failed
-import strikt.assertions.isA
-import strikt.assertions.isEqualTo
+import strikt.assertions.*
 
 internal class TagMatcherTest {
     @Nested
@@ -80,31 +77,41 @@ internal class TagMatcherTest {
                 // When
                 expectCatching { TagMatcher.parse(tagName, "[$pathMatcher]") }
                         .failed()
-                        .isA<NotAbsolutePathMatcherPathException>()
+                        .isA<PathMatcherUsesEnvironmentVariables>()
             }
 
             @Test
-            fun `should throw an exception when path matcher contains relative path`() {
+            fun `should throw an exception when path matcher starts with $HOME`() {
+                // Given
+                val pathMatcher = "\$HOME/me/path"
+                val tagName = "tag"
+
+                // When
+                expectCatching { TagMatcher.parse(tagName, "[$pathMatcher]") }
+                        .failed()
+                        .isA<PathMatcherUsesEnvironmentVariables>()
+            }
+
+            @Test
+            fun `should not throw an exception when path matcher contains relative path`() {
                 // Given
                 val pathMatcher = "/me/../path"
                 val tagName = "tag"
 
                 // When
                 expectCatching { TagMatcher.parse(tagName, "[$pathMatcher]") }
-                        .failed()
-                        .isA<NotAbsolutePathMatcherPathException>()
+                        .succeeded()
             }
 
             @Test
-            fun `should throw an exception when path matcher starts with dot`() {
+            fun `should not throw an exception when path matcher starts with dot`() {
                 // Given
                 val pathMatcher = "./path"
                 val tagName = "tag"
 
                 // When
                 expectCatching { TagMatcher.parse(tagName, "[$pathMatcher]") }
-                        .failed()
-                        .isA<NotAbsolutePathMatcherPathException>()
+                        .succeeded()
             }
         }
     }


### PR DESCRIPTION
In the last release, a feature was done to forbid relative path matchers they were thought not to work. Relative path matchers are actually supported. What is not supported is environment variables (such as ~). I changed the check, the tests, and the exception message to make it explicit.

Fixes #107