### PR TITLE
#122 GitHub CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,8 +18,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Define Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Build
-        run: ./gradlew build
+        run: ./gradlew build --build-cache
 
       - name: Upload Unit Test Results
         if: always()

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -37,10 +37,7 @@ jobs:
         with:
           name: tests-results # Name artifact for storage in cache
           path: |
-            modules/cli/build/test-results/**/*.xml
-            modules/core/build/test-results/**/*.xml
-            modules/driver-mongo/build/test-results/**/*.xml
-            modules/test/build/test-results/**/*.xml
+            modules/**/build/test-results/**/*.xml
 
 
   publish-test-results:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,55 @@
+name: CI
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E52529D4
+      - run: echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y gnupg
+      - run: sudo apt-get install -y mongodb-org-shell
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests-results # Name artifact for storage in cache
+          path: |
+            modules/cli/build/test-results/**/*.xml
+            modules/core/build/test-results/**/*.xml
+            modules/driver-mongo/build/test-results/**/*.xml
+            modules/test/build/test-results/**/*.xml
+
+
+  publish-test-results:
+    name: Publish tests results
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    # the build-and-test job might be skipped, we don't need to run this job then
+    if: success() || failure()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: tests-results # Name of artifact in cache
+          path: tests-results/
+
+      - name: Publish Unit Test Results
+        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1
+        if: always()
+        with:
+          github_token: ${{ github.token }}
+          files: tests-results/**/*.xml

--- a/modules/core/src/test/kotlin/datamaintain/core/script/FileScriptTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/script/FileScriptTest.kt
@@ -1,6 +1,5 @@
 package datamaintain.core.script
 
-import datamaintain.core.exception.DatamaintainFileIdentifierPatternException
 import org.junit.jupiter.api.Test
 import strikt.api.expectCatching
 import strikt.api.expectThat
@@ -8,6 +7,7 @@ import strikt.assertions.failed
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import java.nio.file.Paths
+import datamaintain.core.exception.DatamaintainFileIdentifierPatternException
 
 internal class FileScriptTest {
     @Test


### PR DESCRIPTION
Add a workflow to manage CI (via github actions)
On each push this workflow will be launched. If one step fails, then author of the commit receive an email.
You can see the result here : https://github.com/4sh/datamaintain/actions/runs/721968944

Resolves #122

Reviewers : @Lysoun @nroulon 
