### PR TITLE
:hammer: #130 Build CLI before release docker packages

### DIFF
--- a/modules/cli/docker-build-push.sh
+++ b/modules/cli/docker-build-push.sh
@@ -16,6 +16,7 @@ docker_build_datamaintain() {
   docker push "$image_build"
 }
 
+./"$script_dir"/../../gradlew clean build
 docker_build_datamaintain "$mongo_3_2_dockerfile" 3.2
 docker_build_datamaintain "$mongo_3_2_dockerfile" 3.4
 docker_build_datamaintain "$mongo_3_6_dockerfile" 3.6


### PR DESCRIPTION
Closes #130
I'm afraid that building Datamaintain in the Dockerfile will make the build way longer. Since there are 4 different docker files, that will make 4 builds. I added the ```./gradlew clean build``` in the script used to produce all the images, tell me if you think it would be better to do that in the docker files but it does not seem to me like they would be able to share the same cache to prevent rebuilding the CLI multiple times.