### PR TITLE
:recycle: Extract report domain to module

### DIFF
--- a/modules/cli/src/main/kotlin/datamaintain/cli/app/update/db/DatamaintainCliUpdateDbCommand.kt
+++ b/modules/cli/src/main/kotlin/datamaintain/cli/app/update/db/DatamaintainCliUpdateDbCommand.kt
@@ -4,6 +4,7 @@ import datamaintain.cli.app.DatamaintainCliCommand
 import datamaintain.core.Datamaintain
 import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.exception.DatamaintainException
+import datamaintain.core.report.print
 import kotlin.system.exitProcess
 
 fun defaultUpdateDbRunner(config: DatamaintainConfig) {

--- a/modules/cli/src/main/kotlin/datamaintain/cli/app/update/db/MarkOneScriptAsExecuted.kt
+++ b/modules/cli/src/main/kotlin/datamaintain/cli/app/update/db/MarkOneScriptAsExecuted.kt
@@ -5,7 +5,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import datamaintain.cli.app.utils.detailedOption
 import datamaintain.core.config.CoreConfigKey
 import datamaintain.core.config.DatamaintainConfig
-import datamaintain.core.script.ScriptAction
+import datamaintain.domain.script.ScriptAction
 import java.util.*
 
 class MarkOneScriptAsExecuted(runner: (DatamaintainConfig) -> Unit = ::defaultUpdateDbRunner) :

--- a/modules/cli/src/main/kotlin/datamaintain/cli/app/update/db/UpdateDb.kt
+++ b/modules/cli/src/main/kotlin/datamaintain/cli/app/update/db/UpdateDb.kt
@@ -9,11 +9,11 @@ import datamaintain.cli.app.utils.detailedOption
 import datamaintain.core.config.CoreConfigKey
 import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.db.driver.DriverConfigKey
-import datamaintain.core.script.ScriptAction
 import datamaintain.core.step.check.allCheckRuleNames
 import datamaintain.core.step.executor.ExecutionMode
 import datamaintain.db.driver.mongo.MongoConfigKey
 import datamaintain.db.driver.mongo.MongoShell
+import datamaintain.domain.script.ScriptAction
 import java.util.*
 
 class UpdateDb(runner: (DatamaintainConfig) -> Unit = ::defaultUpdateDbRunner) : DatamaintainCliUpdateDbCommand(

--- a/modules/cli/src/test/kotlin/datamaintain/cli/app/update/db/MarkOneScriptAsExecutedTest.kt
+++ b/modules/cli/src/test/kotlin/datamaintain/cli/app/update/db/MarkOneScriptAsExecutedTest.kt
@@ -1,7 +1,7 @@
 package datamaintain.cli.app.update.db
 
 import datamaintain.cli.app.BaseCliTest
-import datamaintain.core.script.ScriptAction
+import datamaintain.domain.script.ScriptAction
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat

--- a/modules/cli/src/test/kotlin/datamaintain/cli/app/update/db/UpdateDbTest.kt
+++ b/modules/cli/src/test/kotlin/datamaintain/cli/app/update/db/UpdateDbTest.kt
@@ -2,12 +2,12 @@ package datamaintain.cli.app.update.db
 
 import datamaintain.cli.app.BaseCliTest
 import datamaintain.core.config.DatamaintainConfig
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.Tag
 import datamaintain.core.script.TagMatcher
 import datamaintain.core.step.check.rules.implementations.SameScriptsAsExecutedCheck
 import datamaintain.db.driver.mongo.MongoDriverConfig
 import datamaintain.db.driver.mongo.MongoShell
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.Tag
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -24,6 +24,8 @@ publishing {
 }
 
 dependencies {
+    api(project(":modules:domain-report"))
+
     "testImplementation"("ch.qos.logback:logback-classic:${Versions.logbackClassic}")
 }
 

--- a/modules/core/src/main/kotlin/datamaintain/core/Context.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/Context.kt
@@ -2,8 +2,7 @@ package datamaintain.core
 
 import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.db.driver.DatamaintainDriver
-import datamaintain.core.report.Report
-import datamaintain.core.report.ReportBuilder
+import datamaintain.domain.report.ReportBuilder
 
 data class Context(
         val config: DatamaintainConfig,

--- a/modules/core/src/main/kotlin/datamaintain/core/Datamaintain.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/Datamaintain.kt
@@ -1,7 +1,6 @@
 package datamaintain.core
 
 import datamaintain.core.config.DatamaintainConfig
-import datamaintain.core.report.Report
 import datamaintain.core.step.Filter
 import datamaintain.core.step.Pruner
 import datamaintain.core.step.Scanner
@@ -9,6 +8,7 @@ import datamaintain.core.step.check.Checker
 import datamaintain.core.step.check.CheckerData
 import datamaintain.core.step.executor.Executor
 import datamaintain.core.step.sort.Sorter
+import datamaintain.domain.report.Report
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}

--- a/modules/core/src/main/kotlin/datamaintain/core/config/DatamaintainConfig.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/config/DatamaintainConfig.kt
@@ -4,10 +4,10 @@ import datamaintain.core.config.ConfigKey.Companion.overrideBySystemProperties
 import datamaintain.core.config.CoreConfigKey.*
 import datamaintain.core.db.driver.DatamaintainDriverConfig
 import datamaintain.core.exception.DatamaintainBuilderMandatoryException
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.Tag
 import datamaintain.core.script.TagMatcher
 import datamaintain.core.step.executor.ExecutionMode
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.Tag
 import mu.KotlinLogging
 import java.io.File
 import java.io.InputStream

--- a/modules/core/src/main/kotlin/datamaintain/core/db/driver/DatamaintainDriver.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/db/driver/DatamaintainDriver.kt
@@ -1,9 +1,9 @@
 package datamaintain.core.db.driver
 
-import datamaintain.core.script.ExecutedScript
-import datamaintain.core.script.LightExecutedScript
-import datamaintain.core.script.ScriptWithContent
 import datamaintain.core.step.executor.Execution
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.LightExecutedScript
+import datamaintain.domain.script.ScriptWithContent
 
 abstract class DatamaintainDriver(protected val uri: String) {
 

--- a/modules/core/src/main/kotlin/datamaintain/core/exception/DatamaintainException.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/exception/DatamaintainException.kt
@@ -1,8 +1,8 @@
 package datamaintain.core.exception
 
-import datamaintain.core.report.Report
-import datamaintain.core.report.ReportBuilder
 import datamaintain.core.step.Step
+import datamaintain.domain.report.Report
+import datamaintain.domain.report.ReportBuilder
 
 class DatamaintainException(
     override val message: String,

--- a/modules/core/src/main/kotlin/datamaintain/core/exception/DatamaintainScriptExecutionException.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/exception/DatamaintainScriptExecutionException.kt
@@ -1,6 +1,6 @@
 package datamaintain.core.exception
 
-import datamaintain.core.script.ExecutedScript
+import datamaintain.domain.script.ExecutedScript
 
 class DatamaintainScriptExecutionException (
     executedScript: ExecutedScript

--- a/modules/core/src/main/kotlin/datamaintain/core/report/Report.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/report/Report.kt
@@ -1,102 +1,60 @@
 package datamaintain.core.report
 
-import datamaintain.core.script.ReportExecutedScript
-import datamaintain.core.script.ScriptWithContent
 import datamaintain.core.step.Step
-import datamaintain.core.step.check.rules.CheckRule
+import datamaintain.domain.report.Report
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 
-class Report @JvmOverloads constructor(
-        val scannedScripts: List<ScriptWithContent> = listOf(),
-        val filteredScripts: List<ScriptWithContent> = listOf(),
-        val prunedScripts: List<ScriptWithContent> = listOf(),
-        val executedScripts: List<ReportExecutedScript> = listOf(),
-        val validatedCheckRules: List<CheckRule> = listOf()
-) {
-    fun print(verbose: Boolean, porcelain: Boolean = false) {
-        val stepWithMaxExecutionOrder: Step = Step.values().asSequence().maxByOrNull { step -> step.executionOrder }!!
-        print(verbose, porcelain, stepWithMaxExecutionOrder)
-    }
-
-    fun print(verbose: Boolean, porcelain: Boolean, maxStepToShow: Step) {
-        if (!porcelain) {
-            logger.info { "Summary => " }
-
-            // Scanner
-            logger.info { "- ${scannedScripts.size} files scanned" }
-            if (verbose) {
-                scannedScripts.forEach {logger.info { " -> ${it.name}" }}
-            }
-
-            if (Step.FILTER.isSameStepOrExecutedBefore(maxStepToShow)) {
-                logger.info { "- ${filteredScripts.size} files filtered" }
-                if (verbose) {
-                    filteredScripts.forEach { logger.info { " -> ${it.name}" } }
-                }
-            }
-
-            if (Step.PRUNE.isSameStepOrExecutedBefore(maxStepToShow)) {
-                logger.info { "- ${prunedScripts.size} files pruned" }
-                if (verbose) {
-                    prunedScripts.forEach { logger.info { " -> ${it.name}" } }
-                }
-            }
-
-            if (Step.CHECK.isSameStepOrExecutedBefore(maxStepToShow)) {
-                logger.info { "- ${validatedCheckRules.size} check rules validated" }
-                if (verbose) {
-                    validatedCheckRules.forEach { logger.info { " -> ${it.getName()}" } }
-                }
-            }
-        }
-
-        if (Step.EXECUTE.isSameStepOrExecutedBefore(maxStepToShow)) {
-            if (!porcelain) { logger.info { "- ${executedScripts.size} files executed" } }
-            executedScripts.forEach {
-                logger.info {
-                    if (!porcelain) { " -> ${it.name}" } else { "${it.porcelainName}" }
-                }
-            }
-        }
-    }
+fun Report.print(verbose: Boolean, porcelain: Boolean = false) {
+    val stepWithMaxExecutionOrder: Step = Step.values().asSequence().maxByOrNull { step -> step.executionOrder }!!
+    print(verbose, porcelain, stepWithMaxExecutionOrder)
 }
 
+fun Report.print(verbose: Boolean, porcelain: Boolean, maxStepToShow: Step) {
+    if (!porcelain) {
+        logger.info { "Summary => " }
 
-class ReportBuilder @JvmOverloads constructor(
-        private val scannedScripts: MutableList<ScriptWithContent> = mutableListOf(),
-        private val filteredScripts: MutableList<ScriptWithContent> = mutableListOf(),
-        private val prunedScripts: MutableList<ScriptWithContent> = mutableListOf(),
-        private val executedScripts: MutableList<ReportExecutedScript> = mutableListOf(),
-        private val validatedCheckRules: MutableList<CheckRule> = mutableListOf()
-) {
+        // Scanner
+        logger.info { "- ${scannedScripts.size} files scanned" }
+        if (verbose) {
+            scannedScripts.forEach { logger.info { " -> ${it.name}" } }
+        }
 
-    fun addScannedScript(script: ScriptWithContent) {
-        scannedScripts.add(script)
+        if (Step.FILTER.isSameStepOrExecutedBefore(maxStepToShow)) {
+            logger.info { "- ${filteredScripts.size} files filtered" }
+            if (verbose) {
+                filteredScripts.forEach { logger.info { " -> ${it.name}" } }
+            }
+        }
+
+        if (Step.PRUNE.isSameStepOrExecutedBefore(maxStepToShow)) {
+            logger.info { "- ${prunedScripts.size} files pruned" }
+            if (verbose) {
+                prunedScripts.forEach { logger.info { " -> ${it.name}" } }
+            }
+        }
+
+        if (Step.CHECK.isSameStepOrExecutedBefore(maxStepToShow)) {
+            logger.info { "- ${validatedCheckRules.size} check rules validated" }
+            if (verbose) {
+                validatedCheckRules.forEach { logger.info { " -> ${it.getName()}" } }
+            }
+        }
     }
 
-    fun addFilteredScript(script: ScriptWithContent) {
-        filteredScripts.add(script)
+    if (Step.EXECUTE.isSameStepOrExecutedBefore(maxStepToShow)) {
+        if (!porcelain) {
+            logger.info { "- ${executedScripts.size} files executed" }
+        }
+        executedScripts.forEach {
+            logger.info {
+                if (!porcelain) {
+                    " -> ${it.name}"
+                } else {
+                    "${it.porcelainName}"
+                }
+            }
+        }
     }
-
-    fun addPrunedScript(script: ScriptWithContent) {
-        prunedScripts.add(script)
-    }
-
-    fun addReportExecutedScript(script: ReportExecutedScript) {
-        executedScripts.add(script)
-    }
-
-    fun addValidatedCheckRules(checkRule: CheckRule) {
-        validatedCheckRules.add(checkRule)
-    }
-
-    fun toReport() = Report(
-            scannedScripts,
-            filteredScripts,
-            prunedScripts,
-            executedScripts,
-            validatedCheckRules
-    )
 }

--- a/modules/core/src/main/kotlin/datamaintain/core/script/FileScript.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/script/FileScript.kt
@@ -1,10 +1,13 @@
 package datamaintain.core.script
 
-import java.math.BigInteger
 import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.exception.DatamaintainFileIdentifierPatternException
 import datamaintain.core.util.extractRelativePath
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.ScriptWithContent
+import datamaintain.domain.script.Tag
 import java.io.File
+import java.math.BigInteger
 import java.nio.file.Path
 import java.security.MessageDigest
 

--- a/modules/core/src/main/kotlin/datamaintain/core/script/TagMatcher.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/script/TagMatcher.kt
@@ -1,6 +1,7 @@
 package datamaintain.core.script
 
 import datamaintain.core.exception.DatamaintainBaseException
+import datamaintain.domain.script.Tag
 import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.nio.file.PathMatcher

--- a/modules/core/src/main/kotlin/datamaintain/core/step/Filter.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/Filter.kt
@@ -3,7 +3,7 @@ package datamaintain.core.step
 import datamaintain.core.Context
 import datamaintain.core.exception.DatamaintainBaseException
 import datamaintain.core.exception.DatamaintainException
-import datamaintain.core.script.ScriptWithContent
+import datamaintain.domain.script.ScriptWithContent
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -11,7 +11,9 @@ private val logger = KotlinLogging.logger {}
 class Filter(private val context: Context) {
     fun filter(scripts: List<ScriptWithContent>): List<ScriptWithContent> {
         try {
-            if (!context.config.porcelain) { logger.info { "Filter scripts..." } }
+            if (!context.config.porcelain) {
+                logger.info { "Filter scripts..." }
+            }
             var filteredScripts = scripts
 
             if (context.config.whitelistedTags.isNotEmpty()) {

--- a/modules/core/src/main/kotlin/datamaintain/core/step/Pruner.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/Pruner.kt
@@ -3,8 +3,8 @@ package datamaintain.core.step
 import datamaintain.core.Context
 import datamaintain.core.exception.DatamaintainBaseException
 import datamaintain.core.exception.DatamaintainException
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.ScriptWithContent
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.ScriptWithContent
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}

--- a/modules/core/src/main/kotlin/datamaintain/core/step/Scanner.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/Scanner.kt
@@ -5,8 +5,8 @@ import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.exception.DatamaintainBaseException
 import datamaintain.core.exception.DatamaintainException
 import datamaintain.core.script.FileScript
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.script.Tag
+import datamaintain.domain.script.ScriptWithContent
+import datamaintain.domain.script.Tag
 import mu.KotlinLogging
 import java.io.File
 import java.nio.file.Path

--- a/modules/core/src/main/kotlin/datamaintain/core/step/check/Checker.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/check/Checker.kt
@@ -4,16 +4,16 @@ import datamaintain.core.Context
 import datamaintain.core.exception.DatamaintainBaseException
 import datamaintain.core.exception.DatamaintainCheckRuleNotFoundException
 import datamaintain.core.exception.DatamaintainException
-import datamaintain.core.script.ScriptWithContent
 import datamaintain.core.step.Step
-import datamaintain.core.step.check.rules.CheckRule
-import datamaintain.core.step.check.rules.ScriptType
 import datamaintain.core.step.check.rules.contracts.FullContextCheckRule
 import datamaintain.core.step.check.rules.contracts.ScriptCheckRule
 import datamaintain.core.step.check.rules.contracts.ScriptWithContextCheckRule
 import datamaintain.core.step.check.rules.implementations.AlwaysFailedCheck
 import datamaintain.core.step.check.rules.implementations.AlwaysSucceedCheck
 import datamaintain.core.step.check.rules.implementations.SameScriptsAsExecutedCheck
+import datamaintain.domain.CheckRule
+import datamaintain.domain.ScriptType
+import datamaintain.domain.script.ScriptWithContent
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}

--- a/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/contracts/FullContextCheckRule.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/contracts/FullContextCheckRule.kt
@@ -1,9 +1,9 @@
 package datamaintain.core.step.check.rules.contracts
 
 import datamaintain.core.exception.DatamaintainCheckException
-import datamaintain.core.script.LightExecutedScript
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.step.check.rules.CheckRule
+import datamaintain.domain.CheckRule
+import datamaintain.domain.script.LightExecutedScript
+import datamaintain.domain.script.ScriptWithContent
 
 abstract class FullContextCheckRule(
         val executedScripts: Sequence<LightExecutedScript>

--- a/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/contracts/ScriptCheckRule.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/contracts/ScriptCheckRule.kt
@@ -1,8 +1,8 @@
 package datamaintain.core.step.check.rules.contracts
 
 import datamaintain.core.exception.DatamaintainCheckException
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.step.check.rules.CheckRule
+import datamaintain.domain.CheckRule
+import datamaintain.domain.script.ScriptWithContent
 
 abstract class ScriptCheckRule: CheckRule {
     /**

--- a/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/contracts/ScriptWithContextCheckRule.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/contracts/ScriptWithContextCheckRule.kt
@@ -1,9 +1,9 @@
 package datamaintain.core.step.check.rules.contracts
 
 import datamaintain.core.exception.DatamaintainCheckException
-import datamaintain.core.script.ExecutedScript
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.step.check.rules.CheckRule
+import datamaintain.domain.CheckRule
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ScriptWithContent
 
 abstract class ScriptWithContextCheckRule(
         executedScripts: Sequence<ExecutedScript>

--- a/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/implementations/AlwaysFailedCheck.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/implementations/AlwaysFailedCheck.kt
@@ -1,9 +1,9 @@
 package datamaintain.core.step.check.rules.implementations
 
 import datamaintain.core.exception.DatamaintainCheckException
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.step.check.rules.ScriptType
 import datamaintain.core.step.check.rules.contracts.ScriptCheckRule
+import datamaintain.domain.ScriptType
+import datamaintain.domain.script.ScriptWithContent
 
 class AlwaysFailedCheck: ScriptCheckRule() {
     override fun check(script: ScriptWithContent) {

--- a/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/implementations/AlwaysSucceedCheck.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/implementations/AlwaysSucceedCheck.kt
@@ -1,8 +1,8 @@
 package datamaintain.core.step.check.rules.implementations
 
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.step.check.rules.ScriptType
 import datamaintain.core.step.check.rules.contracts.ScriptCheckRule
+import datamaintain.domain.ScriptType
+import datamaintain.domain.script.ScriptWithContent
 
 class AlwaysSucceedCheck: ScriptCheckRule() {
     override fun check(script: ScriptWithContent) {

--- a/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/implementations/SameScriptsAsExecutedCheck.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/check/rules/implementations/SameScriptsAsExecutedCheck.kt
@@ -1,10 +1,10 @@
 package datamaintain.core.step.check.rules.implementations
 
 import datamaintain.core.exception.DatamaintainCheckException
-import datamaintain.core.script.LightExecutedScript
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.step.check.rules.ScriptType
 import datamaintain.core.step.check.rules.contracts.FullContextCheckRule
+import datamaintain.domain.ScriptType
+import datamaintain.domain.script.LightExecutedScript
+import datamaintain.domain.script.ScriptWithContent
 
 class SameScriptsAsExecutedCheck(
         executedScripts: Sequence<LightExecutedScript>

--- a/modules/core/src/main/kotlin/datamaintain/core/step/executor/Execution.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/executor/Execution.kt
@@ -1,5 +1,5 @@
 package datamaintain.core.step.executor
 
-import datamaintain.core.script.ExecutionStatus
+import datamaintain.domain.script.ExecutionStatus
 
 data class Execution (val executionStatus: ExecutionStatus, val executionOutput: String? = null)

--- a/modules/core/src/main/kotlin/datamaintain/core/step/sort/ByCaseInsensitiveSeparatorFreeAlphabeticalSortingStrategy.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/sort/ByCaseInsensitiveSeparatorFreeAlphabeticalSortingStrategy.kt
@@ -1,6 +1,6 @@
 package datamaintain.core.step.sort
 
-import datamaintain.core.script.Script
+import datamaintain.domain.script.Script
 import java.util.*
 
 /**

--- a/modules/core/src/main/kotlin/datamaintain/core/step/sort/Sorter.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/sort/Sorter.kt
@@ -3,9 +3,9 @@ package datamaintain.core.step.sort
 import datamaintain.core.Context
 import datamaintain.core.exception.DatamaintainBaseException
 import datamaintain.core.exception.DatamaintainException
-import datamaintain.core.script.Script
-import datamaintain.core.script.ScriptWithContent
 import datamaintain.core.step.Step
+import datamaintain.domain.script.Script
+import datamaintain.domain.script.ScriptWithContent
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}

--- a/modules/core/src/main/kotlin/datamaintain/core/step/sort/SortingStrategy.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/step/sort/SortingStrategy.kt
@@ -1,6 +1,6 @@
 package datamaintain.core.step.sort
 
-import datamaintain.core.script.Script
+import datamaintain.domain.script.Script
 
 abstract class SortingStrategy<U>() {
     abstract fun <T : Script> sort(scripts: List<T>, getter: (T) -> U): List<T>

--- a/modules/core/src/test/kotlin/datamaintain/FilterTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/FilterTest.kt
@@ -5,10 +5,10 @@ import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.db.driver.DatamaintainDriver
 import datamaintain.core.db.driver.FakeDriverConfig
 import datamaintain.core.script.FileScript
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.Tag
 import datamaintain.core.step.Filter
 import datamaintain.core.step.executor.ExecutionMode
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.Tag
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat

--- a/modules/core/src/test/kotlin/datamaintain/core/DatamaintainConfigTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/DatamaintainConfigTest.kt
@@ -4,10 +4,10 @@ import datamaintain.core.config.CoreConfigKey
 import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.db.driver.FakeDriverConfig
 import datamaintain.core.exception.DatamaintainBuilderMandatoryException
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.Tag
 import datamaintain.core.script.TagMatcher
 import datamaintain.core.step.executor.ExecutionMode
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.Tag
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat

--- a/modules/core/src/test/kotlin/datamaintain/core/db/driver/FakeDatamaintainDriver.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/db/driver/FakeDatamaintainDriver.kt
@@ -1,8 +1,8 @@
 package datamaintain.core.db.driver
 
-import datamaintain.core.script.ExecutedScript
-import datamaintain.core.script.ScriptWithContent
 import datamaintain.core.step.executor.Execution
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ScriptWithContent
 
 
 class FakeDatamaintainDriver : DatamaintainDriver("") {

--- a/modules/core/src/test/kotlin/datamaintain/core/report/ReportTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/report/ReportTest.kt
@@ -1,6 +1,7 @@
 package datamaintain.core.report
 
 import ch.qos.logback.classic.Logger
+import datamaintain.domain.report.Report
 import datamaintain.core.step.Step
 import datamaintain.core.step.check.rules.implementations.AlwaysSucceedCheck
 import datamaintain.test.ScriptWithContentWithFixedChecksum

--- a/modules/core/src/test/kotlin/datamaintain/core/script/InMemoryScript.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/script/InMemoryScript.kt
@@ -1,6 +1,9 @@
 package datamaintain.core.script
 
 import datamaintain.core.config.DatamaintainConfig
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.ScriptWithContent
+import datamaintain.domain.script.Tag
 import java.math.BigInteger
 import java.security.MessageDigest
 

--- a/modules/core/src/test/kotlin/datamaintain/core/script/TagMatcherTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/script/TagMatcherTest.kt
@@ -1,5 +1,6 @@
 package datamaintain.core.script
 
+import datamaintain.domain.script.Tag
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import strikt.api.expectCatching

--- a/modules/core/src/test/kotlin/datamaintain/core/script/TagTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/script/TagTest.kt
@@ -1,5 +1,6 @@
 package datamaintain.core.script
 
+import datamaintain.domain.script.Tag
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths

--- a/modules/core/src/test/kotlin/datamaintain/core/step/ExecutorTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/step/ExecutorTest.kt
@@ -6,17 +6,18 @@ import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.db.driver.DatamaintainDriver
 import datamaintain.core.db.driver.FakeDriverConfig
 import datamaintain.core.exception.DatamaintainException
-import datamaintain.core.report.Report
-import datamaintain.core.script.ExecutedScript
-import datamaintain.core.script.ExecutionStatus.KO
-import datamaintain.core.script.ExecutionStatus.OK
 import datamaintain.core.script.InMemoryScript
-import datamaintain.core.script.ScriptAction
 import datamaintain.core.step.executor.Execution
 import datamaintain.core.step.executor.ExecutionMode
 import datamaintain.core.step.executor.Executor
+import datamaintain.core.step.executor.buildExecutedScript
 import datamaintain.core.util.exception.DatamaintainQueryException
 import datamaintain.test.TestAppender
+import datamaintain.domain.report.Report
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ExecutionStatus.KO
+import datamaintain.domain.script.ExecutionStatus.OK
+import datamaintain.domain.script.ScriptAction
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -269,7 +270,7 @@ internal class ExecutorTest {
             script1.copy(action = ScriptAction.MARK_AS_EXECUTED)
         )
 
-        val executedScript = ExecutedScript.build(scripts[0], Execution(OK), context.config.flags)
+        val executedScript = buildExecutedScript(scripts[0], Execution(OK), context.config.flags)
 
         // When
         val report: Report = executor.execute(scripts)

--- a/modules/core/src/test/kotlin/datamaintain/core/step/PrunerTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/step/PrunerTest.kt
@@ -5,6 +5,10 @@ import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.db.driver.DatamaintainDriver
 import datamaintain.core.db.driver.FakeDriverConfig
 import datamaintain.core.script.*
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ExecutionStatus
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.Tag
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test

--- a/modules/core/src/test/kotlin/datamaintain/core/step/ScannerTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/step/ScannerTest.kt
@@ -2,9 +2,9 @@ package datamaintain.core.step
 
 import datamaintain.core.Context
 import datamaintain.core.db.driver.FakeDatamaintainDriver
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.script.Tag
 import datamaintain.core.script.TagMatcher
+import datamaintain.domain.script.ScriptWithContent
+import datamaintain.domain.script.Tag
 import datamaintain.test.buildDatamaintainConfig
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/modules/core/src/test/kotlin/datamaintain/core/step/check/rules/implementations/SameScriptsAsExecutedCheckTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/step/check/rules/implementations/SameScriptsAsExecutedCheckTest.kt
@@ -1,10 +1,9 @@
 package datamaintain.core.step.check.rules.implementations
 
 import datamaintain.core.exception.DatamaintainCheckException
-import datamaintain.core.exception.DatamaintainException
-import datamaintain.core.script.ExecutedScript
-import datamaintain.core.script.ExecutionStatus
-import datamaintain.core.script.ScriptAction
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ExecutionStatus
+import datamaintain.domain.script.ScriptAction
 import datamaintain.test.ScriptWithContentWithFixedChecksum
 import org.junit.jupiter.api.Test
 import strikt.api.expectCatching

--- a/modules/core/src/test/kotlin/datamaintain/core/step/sort/ByCaseInsensitiveSeparatorFreeAlphabeticalSortingStrategyTest.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/step/sort/ByCaseInsensitiveSeparatorFreeAlphabeticalSortingStrategyTest.kt
@@ -1,9 +1,9 @@
 package datamaintain.core.step.sort
 
-import datamaintain.core.script.ExecutedScript
-import datamaintain.core.script.ExecutionStatus
-import datamaintain.core.script.Script
-import datamaintain.core.script.ScriptAction
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ExecutionStatus
+import datamaintain.domain.script.Script
+import datamaintain.domain.script.ScriptAction
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.*

--- a/modules/core/src/test/kotlin/datamaintain/test/DatamaintainConfigBuildingUtils.kt
+++ b/modules/core/src/test/kotlin/datamaintain/test/DatamaintainConfigBuildingUtils.kt
@@ -4,10 +4,10 @@ import datamaintain.core.config.CoreConfigKey
 import datamaintain.core.config.DatamaintainConfig
 import datamaintain.core.db.driver.DatamaintainDriverConfig
 import datamaintain.core.db.driver.FakeDriverConfig
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.Tag
 import datamaintain.core.script.TagMatcher
 import datamaintain.core.step.executor.ExecutionMode
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.Tag
 import java.nio.file.Path
 import java.nio.file.Paths
 

--- a/modules/core/src/test/kotlin/datamaintain/test/ScriptBuildingUtils.kt
+++ b/modules/core/src/test/kotlin/datamaintain/test/ScriptBuildingUtils.kt
@@ -1,7 +1,7 @@
 package datamaintain.test
 
-import datamaintain.core.script.ExecutionStatus
-import datamaintain.core.script.ReportExecutedScript
+import datamaintain.domain.script.ExecutionStatus
+import datamaintain.domain.script.ReportExecutedScript
 
 fun buildReportExecutedScript(scriptName: String, porcelainName: String?) =
     ReportExecutedScript(

--- a/modules/core/src/test/kotlin/datamaintain/test/ScriptWithContentWithfixedHashCode.kt
+++ b/modules/core/src/test/kotlin/datamaintain/test/ScriptWithContentWithfixedHashCode.kt
@@ -1,8 +1,8 @@
 package datamaintain.test
 
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.script.Tag
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.ScriptWithContent
+import datamaintain.domain.script.Tag
 
 class ScriptWithContentWithFixedChecksum(
         override val name: String,

--- a/modules/core/src/test/kotlin/datamaintain/test/TestScriptWithContent.kt
+++ b/modules/core/src/test/kotlin/datamaintain/test/TestScriptWithContent.kt
@@ -1,8 +1,8 @@
 package datamaintain.test
 
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.script.Tag
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.ScriptWithContent
+import datamaintain.domain.script.Tag
 
 class TestScriptWithContent(
         override val name: String,

--- a/modules/domain-report/build.gradle.kts
+++ b/modules/domain-report/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+}

--- a/modules/domain-report/src/main/kotlin/datamaintain/domain/CheckRule.kt
+++ b/modules/domain-report/src/main/kotlin/datamaintain/domain/CheckRule.kt
@@ -1,4 +1,4 @@
-package datamaintain.core.step.check.rules
+package datamaintain.domain
 
 interface CheckRule {
     fun getName(): String

--- a/modules/domain-report/src/main/kotlin/datamaintain/domain/report/Report.kt
+++ b/modules/domain-report/src/main/kotlin/datamaintain/domain/report/Report.kt
@@ -1,0 +1,53 @@
+package datamaintain.domain.report
+
+import datamaintain.domain.CheckRule
+import datamaintain.domain.script.ReportExecutedScript
+import datamaintain.domain.script.ScriptWithContent
+
+class Report @JvmOverloads constructor(
+    val scannedScripts: List<ScriptWithContent> = listOf(),
+    val filteredScripts: List<ScriptWithContent> = listOf(),
+    val prunedScripts: List<ScriptWithContent> = listOf(),
+    val executedScripts: List<ReportExecutedScript> = listOf(),
+    val validatedCheckRules: List<CheckRule> = listOf()
+) {
+
+}
+
+
+class ReportBuilder @JvmOverloads constructor(
+    private val scannedScripts: MutableList<ScriptWithContent> = mutableListOf(),
+    private val filteredScripts: MutableList<ScriptWithContent> = mutableListOf(),
+    private val prunedScripts: MutableList<ScriptWithContent> = mutableListOf(),
+    private val executedScripts: MutableList<ReportExecutedScript> = mutableListOf(),
+    private val validatedCheckRules: MutableList<CheckRule> = mutableListOf()
+) {
+
+    fun addScannedScript(script: ScriptWithContent) {
+        scannedScripts.add(script)
+    }
+
+    fun addFilteredScript(script: ScriptWithContent) {
+        filteredScripts.add(script)
+    }
+
+    fun addPrunedScript(script: ScriptWithContent) {
+        prunedScripts.add(script)
+    }
+
+    fun addReportExecutedScript(script: ReportExecutedScript) {
+        executedScripts.add(script)
+    }
+
+    fun addValidatedCheckRules(checkRule: CheckRule) {
+        validatedCheckRules.add(checkRule)
+    }
+
+    fun toReport() = Report(
+        scannedScripts,
+        filteredScripts,
+        prunedScripts,
+        executedScripts,
+        validatedCheckRules
+    )
+}

--- a/modules/domain-report/src/main/kotlin/datamaintain/domain/script/ExecutionStatus.kt
+++ b/modules/domain-report/src/main/kotlin/datamaintain/domain/script/ExecutionStatus.kt
@@ -1,4 +1,4 @@
-package datamaintain.core.script
+package datamaintain.domain.script
 
 enum class ExecutionStatus {
     OK,

--- a/modules/domain-report/src/main/kotlin/datamaintain/domain/script/Script.kt
+++ b/modules/domain-report/src/main/kotlin/datamaintain/domain/script/Script.kt
@@ -1,6 +1,4 @@
-package datamaintain.core.script
-
-import datamaintain.core.step.executor.Execution
+package datamaintain.domain.script
 
 interface Script {
     val name: String
@@ -52,32 +50,6 @@ open class ExecutedScript @JvmOverloads constructor(
         open val executionOutput: String? = null,
         open val flags: List<String> = listOf()
 ) : LightExecutedScript(name, checksum, identifier) {
-    companion object {
-        fun simulateExecuted(script: ScriptWithContent, executionStatus: ExecutionStatus, flags: List<String>) =
-                ExecutedScript(
-                        script.name,
-                        script.checksum,
-                        script.identifier,
-                        executionStatus,
-                        script.action,
-                        flags = flags
-                )
-
-        fun build(script: ScriptWithContent, execution: Execution, flags: List<String>) = simulateExecuted(script, execution.executionStatus, flags)
-
-        fun build(script: ScriptWithContent, execution: Execution, executionDurationInMillis: Long, flags: List<String>) =
-                ExecutedScript(
-                        script.name,
-                        script.checksum,
-                        script.identifier,
-                        execution.executionStatus,
-                        script.action,
-                        executionDurationInMillis,
-                        execution.executionOutput,
-                        flags
-                )
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/modules/domain-report/src/main/kotlin/datamaintain/domain/script/ScriptAction.kt
+++ b/modules/domain-report/src/main/kotlin/datamaintain/domain/script/ScriptAction.kt
@@ -1,4 +1,4 @@
-package datamaintain.core.script
+package datamaintain.domain.script
 
 enum class ScriptAction {
 

--- a/modules/domain-report/src/main/kotlin/datamaintain/domain/script/Tag.kt
+++ b/modules/domain-report/src/main/kotlin/datamaintain/domain/script/Tag.kt
@@ -1,4 +1,4 @@
-package datamaintain.core.script
+package datamaintain.domain.script
 
 data class Tag(
         val name: String

--- a/modules/driver-jdbc/src/main/kotlin/datamaintain/db/driver/jdbc/JdbcDriver.kt
+++ b/modules/driver-jdbc/src/main/kotlin/datamaintain/db/driver/jdbc/JdbcDriver.kt
@@ -1,8 +1,8 @@
 package datamaintain.db.driver.jdbc
 
 import datamaintain.core.db.driver.DatamaintainDriver
-import datamaintain.core.script.*
 import datamaintain.core.step.executor.Execution
+import datamaintain.domain.script.*
 import datamaintain.db.driver.jdbc.exception.JdbcQueryException
 import java.sql.Connection
 import java.sql.DriverManager

--- a/modules/driver-jdbc/src/test/kotlin/datamaintain/db/driver/jdbc/InMemoryScript.kt
+++ b/modules/driver-jdbc/src/test/kotlin/datamaintain/db/driver/jdbc/InMemoryScript.kt
@@ -1,9 +1,9 @@
 package datamaintain.db.driver.jdbc
 
 import datamaintain.core.config.DatamaintainConfig
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.script.Tag
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.ScriptWithContent
+import datamaintain.domain.script.Tag
 import java.math.BigInteger
 import java.security.MessageDigest
 

--- a/modules/driver-jdbc/src/test/kotlin/datamaintain/db/driver/jdbc/JdbcDriverTest.kt
+++ b/modules/driver-jdbc/src/test/kotlin/datamaintain/db/driver/jdbc/JdbcDriverTest.kt
@@ -1,6 +1,10 @@
 package datamaintain.db.driver.jdbc
 
-import datamaintain.core.script.*
+import datamaintain.core.script.FileScript
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ExecutionStatus
+import datamaintain.domain.script.LightExecutedScript
+import datamaintain.domain.script.ScriptAction
 import datamaintain.db.driver.jdbc.exception.JdbcQueryException
 import io.mockk.every
 import io.mockk.spyk

--- a/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/ExecutedScriptJsonParser.kt
+++ b/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/ExecutedScriptJsonParser.kt
@@ -1,8 +1,8 @@
 package datamaintain.db.driver.mongo
 
-import datamaintain.core.script.ExecutedScript
+import datamaintain.domain.script.ExecutedScript
 
 interface ExecutedScriptJsonParser {
     // Serialize an ExecutedScript to a stringify json document
-    fun serializeExecutedScript(executedScript:ExecutedScript): String
+    fun serializeExecutedScript(executedScript: ExecutedScript): String
 }

--- a/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/LightExecutedScriptJsonParser.kt
+++ b/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/LightExecutedScriptJsonParser.kt
@@ -1,6 +1,6 @@
 package datamaintain.db.driver.mongo
 
-import datamaintain.core.script.LightExecutedScript
+import datamaintain.domain.script.LightExecutedScript
 
 interface LightExecutedScriptJsonParser {
     // parse a stringify json array to an Array of LightExecutedScript

--- a/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/MongoDriver.kt
+++ b/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/MongoDriver.kt
@@ -2,10 +2,14 @@ package datamaintain.db.driver.mongo
 
 import datamaintain.core.db.driver.DatamaintainDriver
 import datamaintain.core.exception.DatamaintainMongoQueryException
-import datamaintain.core.script.*
+import datamaintain.core.script.FileScript
 import datamaintain.core.step.executor.Execution
 import datamaintain.core.util.runProcess
 import datamaintain.db.driver.mongo.serialization.KJsonParser
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ExecutionStatus
+import datamaintain.domain.script.LightExecutedScript
+import datamaintain.domain.script.ScriptWithContent
 import mu.KotlinLogging
 import java.io.InputStream
 import java.nio.file.Path

--- a/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/serialization/KJsonParser.kt
+++ b/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/serialization/KJsonParser.kt
@@ -1,11 +1,11 @@
 package datamaintain.db.driver.mongo.serialization
 
-import datamaintain.core.script.ExecutedScript
-import datamaintain.core.script.ExecutionStatus
-import datamaintain.core.script.LightExecutedScript
-import datamaintain.core.script.ScriptAction
 import datamaintain.db.driver.mongo.ExecutedScriptJsonParser
 import datamaintain.db.driver.mongo.LightExecutedScriptJsonParser
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ExecutionStatus
+import datamaintain.domain.script.LightExecutedScript
+import datamaintain.domain.script.ScriptAction
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString

--- a/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/InMemoryScript.kt
+++ b/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/InMemoryScript.kt
@@ -1,9 +1,9 @@
 package datamaintain.db.driver.mongo
 
 import datamaintain.core.config.DatamaintainConfig
-import datamaintain.core.script.ScriptAction
-import datamaintain.core.script.ScriptWithContent
-import datamaintain.core.script.Tag
+import datamaintain.domain.script.ScriptAction
+import datamaintain.domain.script.ScriptWithContent
+import datamaintain.domain.script.Tag
 import java.math.BigInteger
 import java.security.MessageDigest
 

--- a/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/MongoDriverTest.kt
+++ b/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/MongoDriverTest.kt
@@ -2,10 +2,15 @@ package datamaintain.db.driver.mongo
 
 import com.mongodb.client.model.Filters
 import datamaintain.core.exception.DatamaintainMongoQueryException
-import datamaintain.core.script.*
+import datamaintain.core.script.FileScript
+import datamaintain.core.step.executor.buildExecutedScript
 import datamaintain.db.driver.mongo.serialization.ExecutedScriptDb
 import datamaintain.db.driver.mongo.serialization.toExecutedScriptDb
 import datamaintain.db.driver.mongo.test.AbstractMongoDbTest
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ExecutionStatus
+import datamaintain.domain.script.LightExecutedScript
+import datamaintain.domain.script.ScriptAction
 import org.bson.Document
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -333,7 +338,7 @@ internal class MongoDriverTest : AbstractMongoDbTest() {
         val execution = mongoDriver.executeScript(fileScript)
 
         // Then
-        expectCatching { mongoDriver.markAsExecuted(ExecutedScript.build(fileScript, execution, 0, listOf())) }
+        expectCatching { mongoDriver.markAsExecuted(buildExecutedScript(fileScript, execution, 0, listOf())) }
                 .succeeded()
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "datamaintain"
 include(
         "modules:core",
         "modules:cli",
+        "modules:domain-report",
         "modules:driver-mongo",
         "modules:driver-jdbc",
         "modules:test",


### PR DESCRIPTION
Extract the following classes into a new module, `domain-report`:
- Report
- ExecutionStatus
- Script
- ScriptAction
- Tag
- CheckRule

I wanted Report to be in a domain module, to be able to import it in a new module that will enable Datamaintain to send information to the monitoring server. 
The only thing that changed a little bit is that I moved the build functions out of `ExecutedScript` to put them as extension functions in `Executor`, because it seemed to me that it was not useful in the domain object.