### PR TITLE
Add GitHub Workflow to publish Docker images

### DIFF
--- a/.github/workflows/publish_docker_packages.yaml
+++ b/.github/workflows/publish_docker_packages.yaml
@@ -38,13 +38,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Fix for my GH name having capitals, should be removed
-      - name: set lower case owner name
-        run: |
-          echo "REPO_LC=${REPO,,}" >>${GITHUB_ENV}
-        env:
-          REPO: '${{ github.repository }}'
-
       - name: Build and push (4.0)
         env:
           MONGO_VERSION: 4.0
@@ -54,7 +47,7 @@ jobs:
           push: true
           file: modules/cli/Dockerfile/mongo/4/Dockerfile
           build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/tijmen34/datamaintain:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
 
       - name: Build and push (4.2)
         env:
@@ -65,7 +58,7 @@ jobs:
           push: true
           file: modules/cli/Dockerfile/mongo/4/Dockerfile
           build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/tijmen34/datamaintain:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
 
       - name: Build and push (4.4)
         env:
@@ -76,7 +69,7 @@ jobs:
           push: true
           file: modules/cli/Dockerfile/mongo/4/Dockerfile
           build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/tijmen34/datamaintain:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
 
       - name: Build and push (5.0)
         env:
@@ -87,4 +80,4 @@ jobs:
           push: true
           file: modules/cli/Dockerfile/mongo/5/Dockerfile
           build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/tijmen34/datamaintain:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}

--- a/.github/workflows/publish_docker_packages.yaml
+++ b/.github/workflows/publish_docker_packages.yaml
@@ -1,0 +1,29 @@
+name: Publish docker packages on GitHub
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish docker packages
+        run: ./modules/cli/docker-build-push.sh $TAG
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}

--- a/.github/workflows/publish_docker_packages.yaml
+++ b/.github/workflows/publish_docker_packages.yaml
@@ -5,7 +5,10 @@ on:
     tags:
       - '*'
 
-jobs:
+env:
+  REGISTRY: ghcr.io
+
+jobs: 
   publish:
     runs-on: ubuntu-latest
     permissions:
@@ -15,6 +18,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Gradle build
+        run: |
+          ./gradlew clean build -Denv=prod
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -22,8 +38,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish docker packages
-        run: ./modules/cli/docker-build-push.sh $TAG
-        shell: bash
+      - name: Build and push (4.0)
         env:
-          TAG: ${{ github.ref_name }}
+          MONGO_VERSION: 4.0
+        uses: docker/build-push-action@v3
+        with:
+          context: modules/cli/build/distributions
+          push: true
+          file: modules/cli/Dockerfile/mongo/4/Dockerfile
+          build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}

--- a/.github/workflows/publish_docker_packages.yaml
+++ b/.github/workflows/publish_docker_packages.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build and push (4.0)
         env:
-          MONGO_VERSION: 4.0
+          MONGO_VERSION: "4.0"
         uses: docker/build-push-action@v3
         with:
           context: modules/cli/build/distributions
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push (4.2)
         env:
-          MONGO_VERSION: 4.2
+          MONGO_VERSION: "4.2"
         uses: docker/build-push-action@v3
         with:
           context: modules/cli/build/distributions
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build and push (4.4)
         env:
-          MONGO_VERSION: 4.4
+          MONGO_VERSION: "4.4"
         uses: docker/build-push-action@v3
         with:
           context: modules/cli/build/distributions
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build and push (5.0)
         env:
-          MONGO_VERSION: 5.0
+          MONGO_VERSION: "5.0"
         uses: docker/build-push-action@v3
         with:
           context: modules/cli/build/distributions

--- a/.github/workflows/publish_docker_packages.yaml
+++ b/.github/workflows/publish_docker_packages.yaml
@@ -41,9 +41,9 @@ jobs:
       # Fix for my GH name having capitals, should be removed
       - name: set lower case owner name
         run: |
-          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+          echo "REPO_LC=${REPO,,}" >>${GITHUB_ENV}
         env:
-          OWNER: '${{ github.repository_owner }}'
+          REPO: '${{ github.repository }}'
 
       - name: Build and push (4.0)
         env:

--- a/.github/workflows/publish_docker_packages.yaml
+++ b/.github/workflows/publish_docker_packages.yaml
@@ -38,6 +38,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Fix for my GH name having capitals, should be removed
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
       - name: Build and push (4.0)
         env:
           MONGO_VERSION: 4.0
@@ -46,5 +53,38 @@ jobs:
           context: modules/cli/build/distributions
           push: true
           file: modules/cli/Dockerfile/mongo/4/Dockerfile
+          build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+
+      - name: Build and push (4.2)
+        env:
+          MONGO_VERSION: 4.2
+        uses: docker/build-push-action@v3
+        with:
+          context: modules/cli/build/distributions
+          push: true
+          file: modules/cli/Dockerfile/mongo/4/Dockerfile
+          build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+
+      - name: Build and push (4.4)
+        env:
+          MONGO_VERSION: 4.4
+        uses: docker/build-push-action@v3
+        with:
+          context: modules/cli/build/distributions
+          push: true
+          file: modules/cli/Dockerfile/mongo/4/Dockerfile
+          build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+
+      - name: Build and push (5.0)
+        env:
+          MONGO_VERSION: 5.0
+        uses: docker/build-push-action@v3
+        with:
+          context: modules/cli/build/distributions
+          push: true
+          file: modules/cli/Dockerfile/mongo/5/Dockerfile
           build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}

--- a/.github/workflows/publish_docker_packages.yaml
+++ b/.github/workflows/publish_docker_packages.yaml
@@ -47,7 +47,7 @@ jobs:
           push: true
           file: modules/cli/Dockerfile/mongo/4/Dockerfile
           build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
-          tags: ${{ env.REGISTRY }}/tijmen34/datamaintain:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
 
       - name: Build and push (4.2)
         env:
@@ -58,7 +58,7 @@ jobs:
           push: true
           file: modules/cli/Dockerfile/mongo/4/Dockerfile
           build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
-          tags: ${{ env.REGISTRY }}/tijmen34/datamaintain:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
 
       - name: Build and push (4.4)
         env:
@@ -69,7 +69,7 @@ jobs:
           push: true
           file: modules/cli/Dockerfile/mongo/4/Dockerfile
           build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
-          tags: ${{ env.REGISTRY }}/tijmen34/datamaintain:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
 
       - name: Build and push (5.0)
         env:
@@ -80,4 +80,4 @@ jobs:
           push: true
           file: modules/cli/Dockerfile/mongo/5/Dockerfile
           build-args: MONGO_MAJOR=${{ env.MONGO_VERSION }}
-          tags: ${{ env.REGISTRY }}/tijmen34/datamaintain:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}-mongo-${{ env.MONGO_VERSION }}


### PR DESCRIPTION
1. Brief summary of the pull request; not necessary if everything is already said in the pull request name

This PR aims to add a workflow that triggers on every tag that is created. It will then create and push multiple Docker images to the GitHub Docker registry.

Example run can be found [here](https://github.com/Tijmen34/datamaintain/actions/runs/3221309317/jobs/5269086346)

2. Indicate which issue is resolved by your pull request. 

Closes #189 

3. If known, please mention users whose reviews are wanted: @JonhDoe

@Lysoun 

NOTE: Additional ticket(s) can be created to improve this process. Currently, Gradle builds everything, while only the cli is necessary. This can drastically reduce run time. The 4 Docker push steps can also be moved to a new job with a matrix. The important thing here is that the build artifact from Gradle is passed along. The benefit here is that the pushes run in parallel then, saving time as opposed to the sequential approach right now.