### PR TITLE
#208 Configure collection/table name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,12 +24,13 @@
 
 ### Common driver configuration
 
-| Key | Description | Default value | Mandatory? | Values examples |
-|---|---|---|---|---|
-| db.uri | URI to your db server. **Database name is mandatory.**  |  | yes | ```mongodb://localhost/my-db```<br />```mongodb://localhost:8000/my-db```<br />```mongodb://username:password@localhost/my-db```<br />```mongodb+srv://server.example.com/my-db``` <br />```mongodb://my-db,my-db2:27018/my-db``` <br /> |
-| db.trust.uri | Bypass all checks that could be done on your URI because you are very sure of it and think our checks are just liars | ```false``` | no | ```true``` or ```false``` |
-| db.print.output | If true, db output will be logged. | ```false``` | no | ```true``` or ```false``` |
-| db.save.output | If true, db output will be saved in script execution report.  | ```false``` | no | ```true``` or ```false``` |
+| Key             | Description                                                                                                          | Default value     | Mandatory? | Values examples |
+|-----------------|----------------------------------------------------------------------------------------------------------------------|-------------------|---|---|
+| db.uri          | URI to your db server. **Database name is mandatory.**                                                               |                   | yes | ```mongodb://localhost/my-db```<br />```mongodb://localhost:8000/my-db```<br />```mongodb://username:password@localhost/my-db```<br />```mongodb+srv://server.example.com/my-db``` <br />```mongodb://my-db,my-db2:27018/my-db``` <br /> |
+| db.trust.uri    | Bypass all checks that could be done on your URI because you are very sure of it and think our checks are just liars | ```false```       | no | ```true``` or ```false``` |
+| db.print.output | If true, db output will be logged.                                                                                   | ```false```       | no | ```true``` or ```false``` |
+| db.save.output  | If true, db output will be saved in script execution report.                                                         | ```false```       | no | ```true``` or ```false``` |
+| db.executed.scripts.storage.name           | Name of the collection (mongo) or table (SQL) where the executed scripts will be stored                              | ``executedScripts`` | no | ``executedScripts`` |
 
 ### Specific mongodb driver configuration
 

--- a/modules/cli/src/main/kotlin/datamaintain/cli/app/DatamaintainCLI.kt
+++ b/modules/cli/src/main/kotlin/datamaintain/cli/app/DatamaintainCLI.kt
@@ -67,6 +67,11 @@ class Datamaintain : CliktCommand() {
         defaultValue = MongoConfigKey.DB_MONGO_TMP_PATH.default
     )
 
+    private val executedScriptsStorageName: String? by detailedOption(
+        help = "executed scripts storage (table/collection) name, the executed scripts will be stored in the specified storage",
+        defaultValue = DriverConfigKey.EXECUTED_SCRIPTS_STORAGE_NAME.default
+    )
+
     private val config: Boolean? by option(help = "Print the configuration without executing the subcommand").flag()
 
     private val props by findOrSetObject<Properties> { -> Properties() }
@@ -97,6 +102,7 @@ class Datamaintain : CliktCommand() {
 
         mongoTmpPath?.let { props.put(MongoConfigKey.DB_MONGO_TMP_PATH.key, it) }
         trustUri?.let { props.put(DriverConfigKey.DB_TRUST_URI.key, it.toString()) }
+        executedScriptsStorageName?.let { props.put(DriverConfigKey.EXECUTED_SCRIPTS_STORAGE_NAME.key, it) }
 
         config?.let { props.put(CliSpecificKey.__PRINT_CONFIG_ONLY.key, it.toString()) }
     }

--- a/modules/cli/src/test/kotlin/datamaintain/cli/app/DatamaintainTest.kt
+++ b/modules/cli/src/test/kotlin/datamaintain/cli/app/DatamaintainTest.kt
@@ -161,6 +161,20 @@ internal class DatamaintainTest : BaseCliTest() {
                     .get { mongoTmpPath }.isEqualTo(mongoTmpPath)
         }
 
+        @Test
+        fun `should build configuration with executed scripts storage name`() {
+            // Given
+            val executedScriptsStorageName = "myExecutedScripts"
+            val argv = listOf("--db-type", "mongo", "--db-uri", "mongouri", "--executed-scripts-storage-name", executedScriptsStorageName)
+
+            // When
+            runAppWithUpdateDb(argv)
+
+            // Then
+            expectThat(configWrapper.datamaintainConfig!!.driverConfig)
+                .get { executedScriptsStorageName }.isEqualTo(executedScriptsStorageName)
+        }
+
         @Nested
         inner class TrustUri {
             @Test

--- a/modules/core/src/main/kotlin/datamaintain/core/db/driver/DatamaintainDriver.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/db/driver/DatamaintainDriver.kt
@@ -5,7 +5,8 @@ import datamaintain.domain.script.ExecutedScript
 import datamaintain.domain.script.LightExecutedScript
 import datamaintain.domain.script.ScriptWithContent
 
-abstract class DatamaintainDriver(protected val uri: String) {
+abstract class DatamaintainDriver(protected val uri: String,
+                                  protected val executedScriptsStorageName: String) {
 
     /**
      * Reads the executed scripts from the database and returns them

--- a/modules/core/src/main/kotlin/datamaintain/core/db/driver/DatamaintainDriverConfig.kt
+++ b/modules/core/src/main/kotlin/datamaintain/core/db/driver/DatamaintainDriverConfig.kt
@@ -7,6 +7,7 @@ abstract class DatamaintainDriverConfig(val dbType: String,
                                         open val trustUri: Boolean,
                                         open val printOutput: Boolean = DriverConfigKey.DB_PRINT_OUTPUT.default!!.toBoolean(),
                                         open val saveOutput: Boolean = DriverConfigKey.DB_SAVE_OUTPUT.default!!.toBoolean(),
+                                        open val executedScriptsStorageName: String = DriverConfigKey.EXECUTED_SCRIPTS_STORAGE_NAME.default!!,
                                         private val connectionStringBuilder: ConnectionStringBuilder) {
 
     fun toDriver(): DatamaintainDriver {
@@ -29,5 +30,6 @@ enum class DriverConfigKey(override val key: String,
     DB_URI("db.uri"),
     DB_TRUST_URI("db.trust.uri", "false"),
     DB_PRINT_OUTPUT("db.print.output", "false"),
-    DB_SAVE_OUTPUT("db.save.output", "false")
+    DB_SAVE_OUTPUT("db.save.output", "false"),
+    EXECUTED_SCRIPTS_STORAGE_NAME("db.executed.scripts.storage.name", "executedScripts")
 }

--- a/modules/core/src/test/kotlin/datamaintain/core/db/driver/FakeDatamaintainDriver.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/db/driver/FakeDatamaintainDriver.kt
@@ -5,7 +5,7 @@ import datamaintain.domain.script.ExecutedScript
 import datamaintain.domain.script.ScriptWithContent
 
 
-class FakeDatamaintainDriver : DatamaintainDriver("") {
+class FakeDatamaintainDriver : DatamaintainDriver("", "") {
     override fun executeScript(script: ScriptWithContent): Execution {
         throw NotImplementedError("FakeDatamaintainDriver executeScript method should not be used")
     }

--- a/modules/core/src/test/kotlin/datamaintain/core/db/driver/FakeDriverConfig.kt
+++ b/modules/core/src/test/kotlin/datamaintain/core/db/driver/FakeDriverConfig.kt
@@ -3,8 +3,15 @@ package datamaintain.core.db.driver
 import datamaintain.core.exception.DatamaintainBaseException
 
 class FakeDriverConfig : 
-        DatamaintainDriverConfig( "fake","",true, false, false,
-                ConnectionStringBuilder(".*") { DatamaintainBaseException("") }) {
+        DatamaintainDriverConfig(
+            dbType = "fake",
+            uri = "",
+            trustUri = true,
+            printOutput = false,
+            saveOutput = false,
+            connectionStringBuilder = ConnectionStringBuilder(".*") { DatamaintainBaseException("") },
+            executedScriptsStorageName = "fakeExecutedScripts"
+        ) {
     override fun log() {
     }
 

--- a/modules/driver-jdbc/src/main/kotlin/datamaintain/db/driver/jdbc/JdbcDriver.kt
+++ b/modules/driver-jdbc/src/main/kotlin/datamaintain/db/driver/jdbc/JdbcDriver.kt
@@ -18,11 +18,9 @@ import java.util.*
  * connection should be left as default value.
  */
 class JdbcDriver(jdbcUri: String,
-                 private val connection: Connection = DriverManager.getConnection(jdbcUri)) : DatamaintainDriver(jdbcUri) {
-
-    companion object {
-        const val EXECUTED_SCRIPTS_TABLE = "executedScripts"
-    }
+                 executedScriptsTableName: String,
+                 private val connection: Connection = DriverManager.getConnection(jdbcUri)
+) : DatamaintainDriver(jdbcUri, executedScriptsTableName) {
 
     override fun executeScript(script: ScriptWithContent): Execution {
         return try {

--- a/modules/driver-jdbc/src/main/kotlin/datamaintain/db/driver/jdbc/JdbcDriver.kt
+++ b/modules/driver-jdbc/src/main/kotlin/datamaintain/db/driver/jdbc/JdbcDriver.kt
@@ -35,7 +35,7 @@ class JdbcDriver(jdbcUri: String,
         createExecutedScriptsTableIfNotExists()
 
         val statement = connection.createStatement()
-        val executionOutput: ResultSet = statement.executeQuery("SELECT name, checksum, identifier from $EXECUTED_SCRIPTS_TABLE")
+        val executionOutput: ResultSet = statement.executeQuery("SELECT name, checksum, identifier from $executedScriptsStorageName")
         val executedScript = mutableListOf<LightExecutedScript>()
         while (executionOutput.next()) {
             executedScript.add(executionOutput.toLightExecutedScript())
@@ -45,7 +45,7 @@ class JdbcDriver(jdbcUri: String,
 
     override fun markAsExecuted(executedScript: ExecutedScript): ExecutedScript {
         val insertStmt = connection.prepareStatement("""
-            INSERT INTO $EXECUTED_SCRIPTS_TABLE (id, name, checksum, identifier, executionStatus, action) 
+            INSERT INTO $executedScriptsStorageName (id, name, checksum, identifier, executionStatus, action) 
             VALUES (?, ?, ?, ?, ?, ?)"""
         )
 
@@ -70,7 +70,7 @@ class JdbcDriver(jdbcUri: String,
 
     fun createExecutedScriptsTableIfNotExists() {
         val tableCreationStatement = connection.prepareStatement("""
-            CREATE TABLE IF NOT EXISTS $EXECUTED_SCRIPTS_TABLE (
+            CREATE TABLE IF NOT EXISTS $executedScriptsStorageName (
                 id VARCHAR(255) NOT NULL,
                 name VARCHAR(255) NOT NULL,
                 checksum VARCHAR(255) NOT NULL,
@@ -86,7 +86,7 @@ class JdbcDriver(jdbcUri: String,
 
     override fun overrideScript(executedScript: ExecutedScript): ExecutedScript {
         connection.prepareStatement("""
-            UPDATE $EXECUTED_SCRIPTS_TABLE SET
+            UPDATE $executedScriptsStorageName SET
             action = '${ScriptAction.OVERRIDE_EXECUTED.name}',
             checksum = '${executedScript.checksum}',
             executionStatus = '${ExecutionStatus.OK.name}'

--- a/modules/driver-jdbc/src/test/kotlin/datamaintain/db/driver/jdbc/JdbcDriverConfigTest.kt
+++ b/modules/driver-jdbc/src/test/kotlin/datamaintain/db/driver/jdbc/JdbcDriverConfigTest.kt
@@ -31,10 +31,12 @@ internal class JdbcDriverConfigTest {
         val updatedURI = "jdbc://localhost/my-db"
         System.setProperty("db.uri", updatedURI)
         System.setProperty("db.trust.uri", "false")
+        System.setProperty("db.executed.scripts.storage.name", "myStorageName")
 
         expectThat(JdbcDriverConfig.buildConfig(props)).and {
             get { uri }.isEqualTo(updatedURI)
             get { trustUri }.isFalse()
+            get { executedScriptsStorageName } isEqualTo "myStorageName"
         }
     }
 
@@ -47,6 +49,7 @@ internal class JdbcDriverConfigTest {
                 .withSaveOutput(true)
                 .withTrustUri(true)
                 .withPrintOutput(true)
+                .withExecutedScriptsStorageName("myStorageName")
                 .build()
 
             expectThat(config).and {
@@ -54,6 +57,7 @@ internal class JdbcDriverConfigTest {
                 get { saveOutput }.isTrue()
                 get { trustUri }.isTrue()
                 get { printOutput }.isTrue()
+                get { executedScriptsStorageName } isEqualTo "myStorageName"
             }
         }
 
@@ -68,6 +72,7 @@ internal class JdbcDriverConfigTest {
                 get { saveOutput }.isFalse()
                 get { trustUri }.isFalse()
                 get { printOutput }.isFalse()
+                get { executedScriptsStorageName } isEqualTo "executedScripts"
             }
         }
 

--- a/modules/driver-jdbc/src/test/resources/config/default.properties
+++ b/modules/driver-jdbc/src/test/resources/config/default.properties
@@ -1,2 +1,3 @@
 db.uri=jdbc:h2:mem:
 db.trust.uri=true
+db.executed.scripts.storage.name=myStorageName

--- a/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/MongoDriver.kt
+++ b/modules/driver-mongo/src/main/kotlin/datamaintain/db/driver/mongo/MongoDriver.kt
@@ -19,12 +19,16 @@ import kotlin.streams.toList
 private val logger = KotlinLogging.logger {}
 
 class MongoDriver(mongoUri: String,
+                  executedScriptsCollectionName: String,
                   private val tmpFilePath: Path,
                   private val clientExecutable: String,
                   private val printOutput: Boolean,
                   private val saveOutput: Boolean,
-                  private val mongoShell: MongoShell
-) : DatamaintainDriver(mongoUri) {
+                  private val mongoShell: MongoShell,
+) : DatamaintainDriver(
+    uri = mongoUri,
+    executedScriptsStorageName = executedScriptsCollectionName
+) {
     private val jsonParser = KJsonParser()
 
     companion object {

--- a/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/ExecutedScriptBuilder.kt
+++ b/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/ExecutedScriptBuilder.kt
@@ -1,0 +1,23 @@
+package datamaintain.db.driver.mongo
+
+import datamaintain.domain.script.ExecutedScript
+import datamaintain.domain.script.ExecutionStatus
+import datamaintain.domain.script.ScriptAction
+
+fun buildExecutedScript(
+    name: String = "script3.js",
+    checksum: String = "d3d9446802a44259755d38e6d163e820",
+    identifier: String = "",
+    executionStatus: ExecutionStatus = ExecutionStatus.OK,
+    action: ScriptAction = ScriptAction.RUN,
+    executionDurationInMillis: Long = 0,
+    executionOutput: String = "test"
+): ExecutedScript = ExecutedScript(
+    name = name,
+    checksum = checksum,
+    identifier = identifier,
+    executionStatus = executionStatus,
+    action = action,
+    executionDurationInMillis = executionDurationInMillis,
+    executionOutput = executionOutput
+)

--- a/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/MongoDriverConfigTest.kt
+++ b/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/MongoDriverConfigTest.kt
@@ -1,5 +1,6 @@
 package datamaintain.db.driver.mongo
 
+import datamaintain.core.db.driver.DriverConfigKey
 import datamaintain.core.exception.DatamaintainBuilderMandatoryException
 import datamaintain.db.driver.mongo.exception.DatamaintainMongoClientNotFound
 import io.mockk.every
@@ -29,6 +30,7 @@ internal class MongoDriverConfigTest {
             get { tmpFilePath }.isEqualTo(Paths.get("/tmp/test"))
             get { printOutput }.isEqualTo(true)
             get { saveOutput }.isEqualTo(true)
+            get { executedScriptsStorageName }.isEqualTo("myCollectionName")
         }
     }
 
@@ -38,11 +40,14 @@ internal class MongoDriverConfigTest {
         props.load(MongoDriverConfigTest::class.java.getResourceAsStream("/config/default.properties"))
 
         val updatedURI = "mongodb://localhost:27017/newName"
+        val updatedCollectionName = "myCollectionNameFromJvm"
         System.setProperty("db.uri", updatedURI)
+        System.setProperty("db.executed.scripts.storage.name", updatedCollectionName)
 
         expectThat(MongoDriverConfig.buildConfig(props)).and {
             get { uri }.isEqualTo(updatedURI)
             get { tmpFilePath }.isEqualTo(Paths.get("/tmp/test"))
+            get { executedScriptsStorageName }.isEqualTo("myCollectionNameFromJvm")
         }
     }
 
@@ -58,6 +63,7 @@ internal class MongoDriverConfigTest {
                 .withTmpFilePath(Paths.get("/tmpFile"))
                 .withMongoShell(MongoShell.MONGOSH)
                 .withClientExecutable("/clientPath")
+                .withExecutedScriptsCollectionName("myCollectionName")
                 .build()
 
             expectThat(config).and {
@@ -68,6 +74,7 @@ internal class MongoDriverConfigTest {
                 get { tmpFilePath } isEqualTo Paths.get("/tmpFile")
                 get { mongoShell } isEqualTo MongoShell.MONGOSH
                 get { clientExecutable } isEqualTo "/clientPath"
+                get { executedScriptsStorageName } isEqualTo "myCollectionName"
             }
         }
 
@@ -85,6 +92,7 @@ internal class MongoDriverConfigTest {
                 get { tmpFilePath } isEqualTo Paths.get(MongoConfigKey.DB_MONGO_TMP_PATH.default!!)
                 get { mongoShell } isEqualTo MongoShell.MONGO
                 get { clientExecutable } isEqualTo MongoShell.MONGO.defaultBinaryName()
+                get { executedScriptsStorageName } isEqualTo DriverConfigKey.EXECUTED_SCRIPTS_STORAGE_NAME.default!!
             }
         }
 

--- a/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/MongoDriverTest.kt
+++ b/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/MongoDriverTest.kt
@@ -229,14 +229,8 @@ internal class MongoDriverTest : AbstractMongoDbTest() {
             printOutput = false,
             saveOutput = true
         )
-        val script3 = ExecutedScript(
-                "script3.js",
-                "d3d9446802a44259755d38e6d163e820",
-                "",
-                ExecutionStatus.OK,
-                ScriptAction.RUN,
-                0,
-                executionOutput = "test"
+        val script3 = buildExecutedScript(
+            executionOutput = "test"
         )
 
         // When
@@ -350,12 +344,8 @@ internal class MongoDriverTest : AbstractMongoDbTest() {
         val mongoDriver: MongoDriver = buildMongoDriver(mongoShell = mongoShell, mongoUri = "mongodb://failUri")
 
         insertDataInDb()
-        val script3 = ExecutedScript(
-            "script3.js",
-            "d3d9446802a44259755d38e6d163e820",
-            "",
-            ExecutionStatus.OK,
-            ScriptAction.MARK_AS_EXECUTED
+        val script3 = buildExecutedScript(
+            action = ScriptAction.MARK_AS_EXECUTED
         )
 
         // When

--- a/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/MongoDriverTest.kt
+++ b/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/MongoDriverTest.kt
@@ -1,6 +1,7 @@
 package datamaintain.db.driver.mongo
 
 import com.mongodb.client.model.Filters
+import datamaintain.core.db.driver.DriverConfigKey
 import datamaintain.core.exception.DatamaintainMongoQueryException
 import datamaintain.core.script.FileScript
 import datamaintain.core.step.executor.buildExecutedScript
@@ -18,7 +19,6 @@ import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.api.expectThrows
 import strikt.assertions.*
-import java.nio.file.Path
 import java.nio.file.Paths
 
 
@@ -432,13 +432,16 @@ internal class MongoDriverTest : AbstractMongoDbTest() {
                                                   mongoShell: MongoShell,
                                                   printOutput: Boolean = false,
                                                   saveOutput: Boolean = false,
-                                                  clientExecutable: String? = null): MongoDriver {
+                                                  clientExecutable: String? = null,
+                                                  executedScriptsCollection: String = DriverConfigKey.EXECUTED_SCRIPTS_STORAGE_NAME.default!!
+    ): MongoDriver {
         initMongoConnection(tag)
         return buildMongoDriver(
             mongoShell = mongoShell,
             printOutput = printOutput,
             saveOutput = saveOutput,
-            clientExecutable = clientExecutable
+            clientExecutable = clientExecutable,
+            executedScriptsCollectionName = executedScriptsCollection
         )
     }
 
@@ -446,7 +449,9 @@ internal class MongoDriverTest : AbstractMongoDbTest() {
                                  mongoUri: String = this.mongoUri(),
                                  printOutput: Boolean = false,
                                  saveOutput: Boolean = false,
-                                 clientExecutable: String? = null): MongoDriver {
+                                 clientExecutable: String? = null,
+                                 executedScriptsCollectionName: String = DriverConfigKey.EXECUTED_SCRIPTS_STORAGE_NAME.default!!
+    ): MongoDriver {
         val clientExecutable = clientExecutable ?: mongoShell.defaultBinaryName()
 
         return MongoDriver(
@@ -455,7 +460,8 @@ internal class MongoDriverTest : AbstractMongoDbTest() {
             clientExecutable = clientExecutable,
             saveOutput = saveOutput,
             printOutput = printOutput,
-            mongoShell = mongoShell
+            mongoShell = mongoShell,
+            executedScriptsCollectionName = executedScriptsCollectionName
         )
     }
 }

--- a/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/test/AbstractMongoDbTest.kt
+++ b/modules/driver-mongo/src/test/kotlin/datamaintain/db/driver/mongo/test/AbstractMongoDbTest.kt
@@ -5,7 +5,7 @@ import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
-import datamaintain.db.driver.mongo.MongoDriver
+import datamaintain.core.db.driver.DriverConfigKey
 import datamaintain.db.driver.mongo.MongoShell
 import org.bson.Document
 import org.junit.jupiter.api.AfterAll
@@ -63,7 +63,7 @@ abstract class AbstractMongoDbTest {
         connectionString = ConnectionString(mongoUri)
         client = MongoClients.create(connectionString)
         database = client.getDatabase(defaultDatabaseName)
-        collection = database.getCollection(MongoDriver.EXECUTED_SCRIPTS_COLLECTION, Document::class.java)
+        collection = database.getCollection(DriverConfigKey.EXECUTED_SCRIPTS_STORAGE_NAME.default!!, Document::class.java)
         cleanDb()
     }
 

--- a/modules/driver-mongo/src/test/resources/config/default.properties
+++ b/modules/driver-mongo/src/test/resources/config/default.properties
@@ -2,3 +2,4 @@ db.uri=mongodb://localhost:27017/test-datamaintain
 db.print.output=true
 db.save.output=true
 db.mongo.tmp.path=/tmp/test
+db.executed.scripts.storage.name=myCollectionName

--- a/modules/test/src/test/kotlin/datamaintain/test/AbstractMongoDbTest.kt
+++ b/modules/test/src/test/kotlin/datamaintain/test/AbstractMongoDbTest.kt
@@ -5,7 +5,7 @@ import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
-import datamaintain.db.driver.mongo.MongoDriver
+import datamaintain.core.db.driver.DriverConfigKey
 import org.bson.Document
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -47,7 +47,7 @@ abstract class AbstractMongoDbTest {
         connectionString = ConnectionString(mongoUri!!)
         client = MongoClients.create(connectionString!!)
         database = client!!.getDatabase(databaseName)
-        collection = database!!.getCollection(MongoDriver.EXECUTED_SCRIPTS_COLLECTION, Document::class.java)
+        collection = database!!.getCollection(DriverConfigKey.EXECUTED_SCRIPTS_STORAGE_NAME.default!!, Document::class.java)
     }
 
     @AfterEach


### PR DESCRIPTION
Enable to configure executed scripts storage name and use them in :
- CLI
- Mongo driver
- Jdbc driver

Resolves #208 